### PR TITLE
Update js configuration defaults to relative paths, not absolute paths

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,6 +10,7 @@ var SiteDomain = "ons.gov.uk"
 var PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/6cc1837"
 
 // DataDiscovery has configuration values for the dataset JS application
+// TODO make this configurable from environment
 var DataDiscovery = struct {
 	AssetsPath  string
 	API_URL     string
@@ -17,7 +18,7 @@ var DataDiscovery = struct {
 	BASE_PATH   string
 }{
 	"https://cdn.ons.gov.uk/dp-dd-react-app/78210cf",
-	"http://localhost:20099",
-	"http://localhost:20010",
+	"/dd/api",
+	"/dd/api/jobs",
 	"/dd",
 }


### PR DESCRIPTION
### What

Update configuration for React app so that it looks for relative paths to the APIs.

### How to review

Should probably be reviewed at the same time as the [other pull request](https://github.com/ONSdigital/dp-dd-frontend-controller/pull/8)

Locally the following requests should return 200s, with expected response from APIs:
- GET request to `localhost:20000/dd/api/datasets` should return all data discovery datasets.
- POST request to `localhost:20000/dd/api/jobs` should return an ID of a new job.
- GET request to `localhost:20000/dd/api/jobs/job/{id}` should return the status of the ID you got in the previous request.

### Who can review

Anyone but me, preferably @ian-kent 

