### PR TITLE
use href instead of url when updating download button link

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,4 +7,4 @@ var DebugMode bool
 var SiteDomain = "ons.gov.uk"
 
 // PatternLibraryAssetsPath is the URL to the CSS and JS assets from the pattern library
-var PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/39c0b5e"
+var PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/c2f8b4d"


### PR DESCRIPTION
### What

use href instead of url when updating download button link