### PR TITLE
Release 1.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM onsdigital/dp-concourse-tools-ubuntu
 
 WORKDIR /app/
 

--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM onsdigital/dp-concourse-tools-ubuntu
 
 WORKDIR /app/
 

--- a/dp-frontend-renderer.nomad
+++ b/dp-frontend-renderer.nomad
@@ -4,8 +4,11 @@ job "dp-frontend-renderer" {
   type        = "service"
 
   update {
-    stagger      = "20s"
-    max_parallel = 1
+    stagger          = "60s"
+    min_healthy_time = "30s"
+    healthy_deadline = "2m"
+    max_parallel     = 1
+    auto_revert      = true
   }
 
   group "web" {
@@ -13,7 +16,8 @@ job "dp-frontend-renderer" {
 
     constraint {
       attribute = "${node.class}"
-      value     = "web"
+      operator  = "regexp"
+      value     = "web.*"
     }
 
     task "dp-frontend-renderer-web" {
@@ -61,12 +65,13 @@ job "dp-frontend-renderer" {
     }
   }
 
-  group "publising" {
+  group "publishing" {
     count = "{{PUBLISHING_TASK_COUNT}}"
 
     constraint {
       attribute = "${node.class}"
-      value     = "publishing"
+      operator  = "regexp"
+      value     = "publishing.*"
     }
 
     task "dp-frontend-renderer-publishing" {

--- a/dp-frontend-renderer.nomad
+++ b/dp-frontend-renderer.nomad
@@ -20,6 +20,13 @@ job "dp-frontend-renderer" {
       value     = "web.*"
     }
 
+    restart {
+      attempts = 3
+      delay    = "15s"
+      interval = "1m"
+      mode     = "delay"
+    }
+
     task "dp-frontend-renderer-web" {
       driver = "docker"
 
@@ -72,6 +79,13 @@ job "dp-frontend-renderer" {
       attribute = "${node.class}"
       operator  = "regexp"
       value     = "publishing.*"
+    }
+
+    restart {
+      attempts = 3
+      delay    = "15s"
+      interval = "1m"
+      mode     = "delay"
     }
 
     task "dp-frontend-renderer-publishing" {


### PR DESCRIPTION
### What

* Various improvements to the nomad plan:
  * Configure the healthy threshold and deadline
  * Enable auto rollback on failed deploy
  * Increase the stagger time to allow enough time for scheduling
  * Allow for splitting the nomad classes so that apps that don't need the content volume can float
  * Add the restart stanza to the nomad plan to support nomad 0.8 for new production.
* Update base docker image to use our Ubuntu image with ca-certificates bundled.

## How to review

Ensure only nomad plan and docker image changes are included.

## Who can review

Anyone but me.