### PR TITLE
Hotfix/3490-no-link-highlighting-on-other-download-options

### DIFF
--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -44,8 +44,8 @@
           </form>
           {{ if gt (len $v.Downloads) 0}}
           <div class="margin-top--2 js-show-hide show-hide show-hide--light show-hide--dark-bg border-top--iron-sm border-top--iron-md border-bottom--iron-sm border-bottom--iron-md col--lg-two-thirds col--md-two-thirds">
-            <div class="js-show-hide__title show-hide__title show-hide__title--link-style margin-top--0 margin-bottom--0 padding-left--1 padding-right--0">
-              <button class="js-show-hide__button js-show-hide__button--slim" type="button" aria-expanded="false" aria-controls="collapsible-0">
+            <div class="js-show-hide__title show-hide__title show-hide__title--link-style margin-top--0 margin-bottom--0 padding-right--0">
+              <button class="js-show-hide__button js-show-hide__button--slim btn--focus padding-left--1" type="button" aria-expanded="false" aria-controls="collapsible-0">
                 <h3 class="margin-top--0 underline-link font-size--17">Other download options</h3>
               </button>
             </div>


### PR DESCRIPTION
### What

Added `.btn--focus` and `.padding-left--1` to the button; the former to add the missing styles and the latter to ensure the border surrounds the entire box, which is not what it would do without this change. 

Removed `.padding-left--1` from the parent div because I have moved this style to the button for aforementioned reasons.

### How to review

Load up page similar to https://beta.ons.gov.uk/datasets/mid-year-pop-est/editions/time-series/versions/1 and tab through. You should notice that the 'Other download options' dropdown button will now be highlighted when tabbed onto. This should be the case when the dropdown is open or closed.

### Who can review

Matt Elcock worked on the changes. Anyone other than him can review.
