### PR TITLE
Hotfix/3496-problematic-navigation-of-preview-table

### DIFF
--- a/assets/templates/dataset-filter/preview-page.tmpl
+++ b/assets/templates/dataset-filter/preview-page.tmpl
@@ -42,7 +42,7 @@
                       <thead>
                           <tr>
                             {{ range .Data.Dimensions }}
-                            <th tabindex="0" scope="col">{{.Name}}</th>
+                            <th scope="col">{{.Name}}</th>
                             {{ end }}
                           </tr>
                       </thead>
@@ -51,7 +51,7 @@
                           {{ range $i, $v := loop 0 (len (index $dimensions 0).Values ) }}
                           <tr>
                             {{ range $j, $dimension := $dimensions }}
-                            <td tabindex="0">{{ index $dimension.Values $i }}</td>
+                            <td>{{ index $dimension.Values $i }}</td>
                             {{ end }}
                           </tr>
                           {{ end }}


### PR DESCRIPTION
### What

Removed `tabindex=0` on `<td>` and `<th>` elements to improve accessibility.

### How to review

Load up a page similar to https://beta.ons.gov.uk/filter-outputs/a609d147-e895-4496-90e3-0ffe7a01d496 and tab through the content. Elements within the table should be skipped when tabbing through and therefore focus styles should not be shown.

### Who can review

Matt Elcock worked on this PR. Anyone other than him can review.
