### PR TITLE
Fix/3489-filter-options-view-latest-release-link-needs-a-description

### DIFF
--- a/assets/templates/partials/latest-release-alert.tmpl
+++ b/assets/templates/partials/latest-release-alert.tmpl
@@ -1,6 +1,6 @@
 <div class="status status--amber margin-right-sm--1 margin-left-sm--1">
     <div class="status__content">This is not the latest release.
-        <a class="status__link" href="{{.Data.LatestVersion.DatasetLandingPageURL}}">View latest release</a>
+        <a class="status__link" href="{{.Data.LatestVersion.DatasetLandingPageURL}}">View latest release <span class="visuallyhidden"> of {{ .DatasetTitle }} dataset</span></a>
     </div>
     <a class="btn btn--primary" href="{{.Data.LatestVersion.FilterJourneyWithLatestJourney}}"><strong>Apply these filters to the latest release</strong></a>
     


### PR DESCRIPTION
### What

Updated latest release alert with proposed code to solve accessibility issue of not providing enough context to screen readers.

### How to review

Load up a page similar to https://beta.ons.gov.uk/filters/2932f66a-819a-440d-853a-959ca78d851b/dimensions and inspect the page. View the text `This is not the latest release. View latest release` and ensure that the following is appended to the end: `<span class="visuallyhidden"> of {{name of dataset}} dataset</span>`.

### Who can review

Matt Elcock worked on these changes. Anyone other than him can review.
