### PR TITLE
Fix/3495-descriptive-table-caption-and-headers

### DIFF
--- a/assets/templates/dataset-filter/preview-page.tmpl
+++ b/assets/templates/dataset-filter/preview-page.tmpl
@@ -39,7 +39,8 @@
                 </ul>
                 <div class="table-preview">
                     <table>
-                      <thead>
+                    <caption>Preview of {{ .DatasetTitle }} </caption>
+                    <thead>
                           <tr>
                             {{ range .Data.Dimensions }}
                             <th tabindex="0" scope="col">{{.Name}}</th>


### PR DESCRIPTION
### What

Added caption to table preview

### How to review

View a page similar to https://beta.ons.gov.uk/filter-outputs/6db6c3d4-0255-490b-a2b3-f0c0088e7287 and ensure that the table preview is captioned with 'Preview of <name of table>`.

### Who can review

Matt Elcock worked on these changes. Anyone other than him may review this.
