### PR TITLE
added new render helper func to create legacy dataset download links

### DIFF
--- a/assets/templates/datasetLandingPage/static.tmpl
+++ b/assets/templates/datasetLandingPage/static.tmpl
@@ -117,7 +117,7 @@
                         {{ $timeseriesDataset := index .DatasetLandingPage.Datasets 0 }}
                         {{ range $timeseriesDataset.Downloads }}
                             <div class="inline-block--md margin-bottom-sm--1">
-                                <a href="/file?uri={{ $timeseriesDataset.URI }}/{{ .URI }}" class="btn btn--primary btn--thick">
+                                <a href="{{ legacyDatasetDownloadURI $timeseriesDataset.URI .URI }}" class="btn btn--primary btn--thick">
                                     <span class="visuallyhidden">Download {{ $.Metadata.Title }} in {{ .Extension }} format</span>
                                     <span class="uppercase">{{ .Extension }} {{ humanSize .Size }}</span>
                                 </a>

--- a/main.go
+++ b/main.go
@@ -5,12 +5,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"reflect"
 	"strconv"
 	"time"
 
-	"github.com/gosimple/slug"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/ONSdigital/dp-frontend-renderer/assets"
 	"github.com/ONSdigital/dp-frontend-renderer/config"
@@ -29,12 +27,12 @@ import (
 	"github.com/ONSdigital/dp-frontend-renderer/handlers/geography/list"
 	"github.com/ONSdigital/dp-frontend-renderer/handlers/homepage"
 	"github.com/ONSdigital/dp-frontend-renderer/handlers/productPage"
+	renderHelpers "github.com/ONSdigital/dp-frontend-renderer/render"
 	"github.com/ONSdigital/go-ns/handlers/requestID"
 	"github.com/ONSdigital/go-ns/handlers/timeout"
 	"github.com/ONSdigital/go-ns/healthcheck"
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/ONSdigital/go-ns/render"
-	"github.com/c2h5oh/datasize"
 	"github.com/gorilla/pat"
 	"github.com/justinas/alice"
 	unrolled "github.com/unrolled/render"
@@ -86,53 +84,15 @@ func main() {
 		IsDevelopment: config.DebugMode,
 		Layout:        "main",
 		Funcs: []template.FuncMap{{
-			"humanSize": func(size string) (string, error) {
-				if size == "" {
-					return "", nil
-				}
-				s, err := strconv.Atoi(size)
-				if err != nil {
-					return "", err
-				}
-				return datasize.ByteSize(s).HumanReadable(), nil
-			},
-			"safeHTML": func(s string) template.HTML {
-				return template.HTML(s)
-			},
-			"dateFormat": func(s string) template.HTML {
-				t, err := time.Parse(time.RFC3339, s)
-				if err != nil {
-					log.Error(err, nil)
-					return template.HTML(s)
-				}
-				return template.HTML(t.Format("02 January 2006"))
-			},
-			"dateFormatYYYYMMDD": func(s string) template.HTML {
-				t, err := time.Parse(time.RFC3339, s)
-				if err != nil {
-					log.Error(err, nil)
-					return template.HTML(s)
-				}
-				return template.HTML(t.Format("2006/01/02"))
-			},
-			"last": func(x int, a interface{}) bool {
-				return x == reflect.ValueOf(a).Len()-1
-			},
-			"loop": func(n, m int) []int {
-				arr := make([]int, m-n)
-				v := n
-				for i := 0; i < m-v; i++ {
-					arr[i] = n
-					n++
-				}
-				return arr
-			},
-			"subtract": func(x, y int) int {
-				return x - y
-			},
-			"slug": func(s string) string {
-				return slug.Make(s)
-			},
+			"humanSize":          renderHelpers.HumanSize,
+			"safeHTML":           renderHelpers.SafeHTML,
+			"dateFormat":         renderHelpers.DateFormat,
+			"dateFormatYYYYMMDD": renderHelpers.DateFormatYYYYMMDD,
+			"last":               renderHelpers.Last,
+			"loop":               renderHelpers.Loop,
+			"subtract":           renderHelpers.Subtract,
+			"slug":               renderHelpers.Slug,
+			"legacyDatasetDownloadURI": renderHelpers.LegacyDataSetDownloadURI,
 			"taxonomyLandingPage": func(s string) string {
 				return taxonomyRedirects[s]
 			},

--- a/render/helpers.go
+++ b/render/helpers.go
@@ -1,0 +1,77 @@
+package render
+
+import (
+	"fmt"
+	"github.com/ONSdigital/go-ns/log"
+	"github.com/c2h5oh/datasize"
+	"github.com/gosimple/slug"
+	"html/template"
+	"reflect"
+	"strconv"
+	"time"
+)
+
+const legacyDatasetURIFormat = "/file?uri=%s/%s"
+
+func HumanSize(size string) (string, error) {
+	if size == "" {
+		return "", nil
+	}
+	s, err := strconv.Atoi(size)
+	if err != nil {
+		return "", err
+	}
+	return datasize.ByteSize(s).HumanReadable(), nil
+}
+
+func SafeHTML(s string) template.HTML {
+	return template.HTML(s)
+}
+
+func DateFormat(s string) template.HTML {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		log.Error(err, nil)
+		return template.HTML(s)
+	}
+	return template.HTML(t.Format("02 January 2006"))
+}
+
+func DateFormatYYYYMMDD(s string) template.HTML {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		log.Error(err, nil)
+		return template.HTML(s)
+	}
+	return template.HTML(t.Format("2006/01/02"))
+}
+
+func Last(x int, a interface{}) bool {
+	return x == reflect.ValueOf(a).Len()-1
+}
+
+func Loop(n, m int) []int {
+	arr := make([]int, m-n)
+	v := n
+	for i := 0; i < m-v; i++ {
+		arr[i] = n
+		n++
+	}
+	return arr
+}
+
+func Subtract(x, y int) int {
+	return x - y
+}
+
+func Slug(s string) string {
+	return slug.Make(s)
+}
+
+// LegacyDataSetDownloadURI builds a URI string for a legacy dataset download URI.
+func LegacyDataSetDownloadURI(pageURI, filename string) string {
+	// Concatenation of strings inside a Href tag causes the URI value to be HTML escaped.
+	// The preference is for our links not to be escaped to maintain readability. To remedy this we build
+	// the link inside this func which is then inserted into template.
+	return fmt.Sprintf(legacyDatasetURIFormat, pageURI, filename)
+}

--- a/render/helpers_test.go
+++ b/render/helpers_test.go
@@ -1,0 +1,38 @@
+package render
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func TestLegacyDatasetDownloadURI(t *testing.T) {
+	Convey("should generated expected legacy dataset download URI", t, func() {
+		So(LegacyDataSetDownloadURI("/legacy/dataset/page", "test.csv"), ShouldEqual, "/file?uri=/legacy/dataset/page/test.csv")
+	})
+}
+
+func TestSubtract(t *testing.T) {
+	Convey("substract should return expected value", t, func() {
+		So(Subtract(100, 1), ShouldEqual, 99)
+	})
+}
+
+func TestHumanSize(t *testing.T) {
+	Convey("humanSize should return the expected value for 1500 bytes", t, func() {
+		res, err := HumanSize("1500")
+		So(err, ShouldBeNil)
+		So(res, ShouldEqual, "1.5 KB")
+	})
+
+	Convey("humanSize should return the expected value for empty input", t, func() {
+		res, err := HumanSize("")
+		So(err, ShouldBeNil)
+		So(res, ShouldBeEmpty)
+	})
+
+	Convey("humanSize should return error for non numeric input", t, func() {
+		res, err := HumanSize("green eggs and ham")
+		So(err, ShouldNotBeNil)
+		So(res, ShouldBeEmpty)
+	})
+}


### PR DESCRIPTION
### What

Concatenating strings inside an `<a Href=""/>` attribute tag causes the string to be HTML escaped. Our preference is for our links not to be escaped to maintain human readability.

I've created a new render helper func for building the legacy dataset download links and used that in place of the current concatenation approach.

Also moved help funcs into separate package and added some unit tests for new func.

### How to review
Running the CMD stack go to a legacy dataset landing page and download the latest version of a file - you should get the file and the download URI should not be escaped.
