### PR TITLE
CMD filterable template styling updated with new Typography

### DIFF
--- a/assets/templates.go
+++ b/assets/templates.go
@@ -110,7 +110,7 @@ func templatesDatasetFilterAgeTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/dataset-filter/age.tmpl", size: 8419, mode: os.FileMode(420), modTime: time.Unix(1543230477, 0)}
+	info := bindataFileInfo{name: "templates/dataset-filter/age.tmpl", size: 8419, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -130,7 +130,7 @@ func templatesDatasetFilterFilterOverviewTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/dataset-filter/filter-overview.tmpl", size: 4665, mode: os.FileMode(420), modTime: time.Unix(1529655599, 0)}
+	info := bindataFileInfo{name: "templates/dataset-filter/filter-overview.tmpl", size: 4665, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -150,7 +150,7 @@ func templatesDatasetFilterGeographyTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/dataset-filter/geography.tmpl", size: 3804, mode: os.FileMode(420), modTime: time.Unix(1526555817, 0)}
+	info := bindataFileInfo{name: "templates/dataset-filter/geography.tmpl", size: 3804, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -170,7 +170,7 @@ func templatesDatasetFilterHierarchyTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/dataset-filter/hierarchy.tmpl", size: 6567, mode: os.FileMode(420), modTime: time.Unix(1543230477, 0)}
+	info := bindataFileInfo{name: "templates/dataset-filter/hierarchy.tmpl", size: 6567, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -190,7 +190,7 @@ func templatesDatasetFilterListSelectorTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/dataset-filter/list-selector.tmpl", size: 3848, mode: os.FileMode(420), modTime: time.Unix(1537950633, 0)}
+	info := bindataFileInfo{name: "templates/dataset-filter/list-selector.tmpl", size: 3848, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -210,7 +210,7 @@ func templatesDatasetFilterPreviewPageTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/dataset-filter/preview-page.tmpl", size: 8300, mode: os.FileMode(420), modTime: time.Unix(1543230477, 0)}
+	info := bindataFileInfo{name: "templates/dataset-filter/preview-page.tmpl", size: 8300, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -230,7 +230,7 @@ func templatesDatasetFilterTimeTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/dataset-filter/time.tmpl", size: 14486, mode: os.FileMode(420), modTime: time.Unix(1537950633, 0)}
+	info := bindataFileInfo{name: "templates/dataset-filter/time.tmpl", size: 14486, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -250,7 +250,7 @@ func templatesDatasetlandingpageEditionListTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/datasetLandingPage/edition-list.tmpl", size: 1042, mode: os.FileMode(420), modTime: time.Unix(1526555817, 0)}
+	info := bindataFileInfo{name: "templates/datasetLandingPage/edition-list.tmpl", size: 1042, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -270,7 +270,7 @@ func templatesDatasetlandingpageFilterableTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/datasetLandingPage/filterable.tmpl", size: 14196, mode: os.FileMode(420), modTime: time.Unix(1537950633, 0)}
+	info := bindataFileInfo{name: "templates/datasetLandingPage/filterable.tmpl", size: 14196, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -290,7 +290,7 @@ func templatesDatasetlandingpageStaticTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/datasetLandingPage/static.tmpl", size: 13780, mode: os.FileMode(420), modTime: time.Unix(1543407110, 0)}
+	info := bindataFileInfo{name: "templates/datasetLandingPage/static.tmpl", size: 13780, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -310,7 +310,7 @@ func templatesDatasetlandingpageVersionListTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/datasetLandingPage/version-list.tmpl", size: 3254, mode: os.FileMode(420), modTime: time.Unix(1526555817, 0)}
+	info := bindataFileInfo{name: "templates/datasetLandingPage/version-list.tmpl", size: 3254, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -330,7 +330,7 @@ func templatesErrorTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/error.tmpl", size: 684, mode: os.FileMode(420), modTime: time.Unix(1524231190, 0)}
+	info := bindataFileInfo{name: "templates/error.tmpl", size: 684, mode: os.FileMode(420), modTime: time.Unix(1552651668, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -350,7 +350,7 @@ func templatesFeedbackTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/feedback.tmpl", size: 5736, mode: os.FileMode(420), modTime: time.Unix(1529655599, 0)}
+	info := bindataFileInfo{name: "templates/feedback.tmpl", size: 5736, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -370,7 +370,7 @@ func templatesGeographyAreaTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/geography/area.tmpl", size: 1787, mode: os.FileMode(420), modTime: time.Unix(1537950975, 0)}
+	info := bindataFileInfo{name: "templates/geography/area.tmpl", size: 1787, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -390,7 +390,7 @@ func templatesGeographyHomepageTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/geography/homepage.tmpl", size: 649, mode: os.FileMode(420), modTime: time.Unix(1537950583, 0)}
+	info := bindataFileInfo{name: "templates/geography/homepage.tmpl", size: 649, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -410,7 +410,7 @@ func templatesGeographyListTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/geography/list.tmpl", size: 666, mode: os.FileMode(420), modTime: time.Unix(1537950583, 0)}
+	info := bindataFileInfo{name: "templates/geography/list.tmpl", size: 666, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -430,7 +430,7 @@ func templatesHomepageTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/homepage.tmpl", size: 11472, mode: os.FileMode(420), modTime: time.Unix(1481017834, 0)}
+	info := bindataFileInfo{name: "templates/homepage.tmpl", size: 11472, mode: os.FileMode(420), modTime: time.Unix(1552397121, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -450,7 +450,7 @@ func templatesMainTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/main.tmpl", size: 2958, mode: os.FileMode(420), modTime: time.Unix(1526555817, 0)}
+	info := bindataFileInfo{name: "templates/main.tmpl", size: 2958, mode: os.FileMode(420), modTime: time.Unix(1556100165, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -470,7 +470,7 @@ func templatesPartialsBreadcrumbTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/breadcrumb.tmpl", size: 893, mode: os.FileMode(420), modTime: time.Unix(1526555817, 0)}
+	info := bindataFileInfo{name: "templates/partials/breadcrumb.tmpl", size: 893, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -490,7 +490,7 @@ func templatesPartialsFeedbackTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/feedback.tmpl", size: 2445, mode: os.FileMode(420), modTime: time.Unix(1529655599, 0)}
+	info := bindataFileInfo{name: "templates/partials/feedback.tmpl", size: 2445, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -510,7 +510,7 @@ func templatesPartialsFilterSelectionTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/filter-selection.tmpl", size: 701, mode: os.FileMode(420), modTime: time.Unix(1526555817, 0)}
+	info := bindataFileInfo{name: "templates/partials/filter-selection.tmpl", size: 701, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -530,7 +530,7 @@ func templatesPartialsFooterTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/footer.tmpl", size: 3969, mode: os.FileMode(420), modTime: time.Unix(1526555817, 0)}
+	info := bindataFileInfo{name: "templates/partials/footer.tmpl", size: 3969, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -550,7 +550,7 @@ func templatesPartialsHeaderTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/header.tmpl", size: 15050, mode: os.FileMode(420), modTime: time.Unix(1536564239, 0)}
+	info := bindataFileInfo{name: "templates/partials/header.tmpl", size: 15050, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -570,7 +570,7 @@ func templatesPartialsLatestReleaseAlertTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/latest-release-alert.tmpl", size: 494, mode: os.FileMode(420), modTime: time.Unix(1537950633, 0)}
+	info := bindataFileInfo{name: "templates/partials/latest-release-alert.tmpl", size: 494, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -590,7 +590,7 @@ func templatesPartialsLoop11Tmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/loop11.tmpl", size: 200, mode: os.FileMode(420), modTime: time.Unix(1526555817, 0)}
+	info := bindataFileInfo{name: "templates/partials/loop11.tmpl", size: 200, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -610,7 +610,7 @@ func templatesPartialsSpinnerTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/spinner.tmpl", size: 932, mode: os.FileMode(420), modTime: time.Unix(1526555817, 0)}
+	info := bindataFileInfo{name: "templates/partials/spinner.tmpl", size: 932, mode: os.FileMode(420), modTime: time.Unix(1553769326, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -630,7 +630,7 @@ func templatesProductpageTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/productPage.tmpl", size: 2869, mode: os.FileMode(420), modTime: time.Unix(1480322790, 0)}
+	info := bindataFileInfo{name: "templates/productPage.tmpl", size: 2869, mode: os.FileMode(420), modTime: time.Unix(1552397121, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -106,18 +106,19 @@
          <section>
            <ol class="list list--custom-numbered">
               <li>
-                <div id="id-dimensions" class="section__content--markdown margin-right--0 margin-left-sm--2">
-                  <h2 class="font-weight-700 padding-top--0">In this dataset</h2>
+                <div id="id-dimensions" class="section__content--markdown margin-right--0">
+                  <h2 class="font-weight-700 padding-top--0 cmd-heading">In this dataset</h2>
                   {{if .DatasetLandingPage.UnitOfMeasurement}}
                   <div class="margin-bottom--3">
-                     <h3 class="font-size--17 font-weight-700">Unit of measurement</h3>
+                     <h3 class="font-size--17 font-weight-700 padding-top--0">Unit of measurement</h3>
                      <p class="padding-top--0">{{.DatasetLandingPage.UnitOfMeasurement}}</p>
                   </div>
                   {{end}}
                   {{range .DatasetLandingPage.Dimensions}}
                   <div class="margin-bottom--3">
-                     <h3 class="font-size--17 font-weight-700">{{.Title}}</h3>
-                     <ul class="dimension-values list list--pipe-seperated js-show-more-list">
+                  <div class="margin-bottom--3">
+                     <h3 class="font-size--17 font-weight-700 padding-top--0">{{.Title}}</h3>
+                     <ul class="dimension-values list list--pipe-seperated js-show-more-list cmd-list">
                         {{$val_length := len .Values}}
                         {{$total_length := .TotalItems}}
                         {{$vals := .Values}}{{range $i, $v := $vals}}
@@ -142,11 +143,11 @@
              </li>
              {{ if .DatasetLandingPage.LatestChanges}}
              <li>
-              <div id="id-changes" class="section__content--markdown margin-right--0 margin-left-sm--2">
-                <h2 class="font-weight-700 padding-top--0">What has changed in this edition</h2>
+              <div id="id-changes" class="section__content--markdown margin-right--0">
+                <h2 class="font-weight-700 padding-top--0 cmd-heading">What has changed in this edition</h2>
                 {{range .DatasetLandingPage.LatestChanges}}
                 <div class="margin-bottom--3">
-                   <h3 class="font-size--17 font-weight-700">{{.Name}}</h3>
+                   <h3 class="font-size--17 font-weight-700 padding-top--0">{{.Name}}</h3>
                    <p class="padding-top--0">{{.Description}}</p>
                 </div>
                 {{ end }}
@@ -156,7 +157,7 @@
             {{end}}
             {{if .DatasetLandingPage.QMIURL}}
             <li>
-             <div id="id-qmi" class="section__content--markdown margin-right--0 margin-left-sm--2">
+             <div id="id-qmi" class="section__content--markdown margin-right--0">
                <h2 class="font-weight-700 padding-top--0">Quality and methodology information</h2>
                <p class="margin-bottom--0">Includes:</p>
                <ul>
@@ -172,8 +173,8 @@
             {{end}}
             {{if .DatasetLandingPage.Methodologies}}
             <li>
-             <div id="id-methodology" class="section__content--markdown margin-right--0 margin-left-sm--2">
-               <h2 class="font-weight-700 padding-top--0">Methodologies</h2>
+             <div id="id-methodology" class="section__content--markdown margin-right--0">
+               <h2 class="font-weight-700 padding-top--0 cmd-heading">Methodologies</h2>
                {{range .DatasetLandingPage.Methodologies}}
                 <h3><a href="{{.URL}}">{{.Title}}</a></h3>
                 <p>{{.Description}}</p>
@@ -184,8 +185,8 @@
             {{end}}
             {{if .DatasetLandingPage.Citation}}
             <li>
-             <div id="id-license" class="section__content--markdown margin-right--0 margin-left-sm--2">
-               <h2 class="font-weight-700 padding-top--0">Usage information</h2>
+             <div id="id-license" class="section__content--markdown margin-right--0">
+               <h2 class="font-weight-700 padding-top--0 cmd-heading">Usage information</h2>
                <p class="margin-bottom--0 padding-bottom--0">{{.DatasetLandingPage.Citation}}</p>
                <a class="inline-block margin-bottom--2" href="/help/termsandconditions">Terms and conditions</a><br>
                <a class="print--hide js-scroll" href="#toc">Back to table of contents</a>
@@ -194,8 +195,8 @@
             {{end}}
             {{if .DatasetLandingPage.HasOlderVersions}}
             <li>
-              <div id="id-previous" class="section__content--markdown margin-right--0 margin-left-sm--2">
-                 <h2 class="font-weight-700 padding-top--0">Previous versions</h2>
+              <div id="id-previous" class="section__content--markdown margin-right--0">
+                 <h2 class="font-weight-700 padding-top--0 cmd-heading">Previous versions</h2>
                  <p><a href="/datasets/{{.DatasetLandingPage.DatasetID}}/editions/{{.DatasetLandingPage.Edition}}/versions">Previous versions</a> of this dataset are available.</p>
               </div>
             </li>

--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -107,7 +107,7 @@
            <ol class="list list--custom-numbered">
               <li>
                 <div id="id-dimensions" class="section__content--markdown margin-right--0">
-                  <h2 class="font-weight-700 padding-top--0 cmd-heading">In this dataset</h2>
+                  <h2 class="font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">In this dataset</h2>
                   {{if .DatasetLandingPage.UnitOfMeasurement}}
                   <div class="margin-bottom--3">
                      <h3 class="font-size--17 font-weight-700 padding-top--0">Unit of measurement</h3>
@@ -118,7 +118,7 @@
                   <div class="margin-bottom--3">
                   <div class="margin-bottom--3">
                      <h3 class="font-size--17 font-weight-700 padding-top--0">{{.Title}}</h3>
-                     <ul class="dimension-values list list--pipe-seperated js-show-more-list cmd-list">
+                     <ul class="dimension-values list list--pipe-seperated js-show-more-list padding-left--0">
                         {{$val_length := len .Values}}
                         {{$total_length := .TotalItems}}
                         {{$vals := .Values}}{{range $i, $v := $vals}}
@@ -144,7 +144,7 @@
              {{ if .DatasetLandingPage.LatestChanges}}
              <li>
               <div id="id-changes" class="section__content--markdown margin-right--0">
-                <h2 class="font-weight-700 padding-top--0 cmd-heading">What has changed in this edition</h2>
+                <h2 class="font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">What has changed in this edition</h2>
                 {{range .DatasetLandingPage.LatestChanges}}
                 <div class="margin-bottom--3">
                    <h3 class="font-size--17 font-weight-700 padding-top--0">{{.Name}}</h3>
@@ -174,7 +174,7 @@
             {{if .DatasetLandingPage.Methodologies}}
             <li>
              <div id="id-methodology" class="section__content--markdown margin-right--0">
-               <h2 class="font-weight-700 padding-top--0 cmd-heading">Methodologies</h2>
+               <h2 class="font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">Methodologies</h2>
                {{range .DatasetLandingPage.Methodologies}}
                 <h3><a href="{{.URL}}">{{.Title}}</a></h3>
                 <p>{{.Description}}</p>
@@ -186,7 +186,7 @@
             {{if .DatasetLandingPage.Citation}}
             <li>
              <div id="id-license" class="section__content--markdown margin-right--0">
-               <h2 class="font-weight-700 padding-top--0 cmd-heading">Usage information</h2>
+               <h2 class="font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">Usage information</h2>
                <p class="margin-bottom--0 padding-bottom--0">{{.DatasetLandingPage.Citation}}</p>
                <a class="inline-block margin-bottom--2" href="/help/termsandconditions">Terms and conditions</a><br>
                <a class="print--hide js-scroll" href="#toc">Back to table of contents</a>
@@ -196,7 +196,7 @@
             {{if .DatasetLandingPage.HasOlderVersions}}
             <li>
               <div id="id-previous" class="section__content--markdown margin-right--0">
-                 <h2 class="font-weight-700 padding-top--0 cmd-heading">Previous versions</h2>
+                 <h2 class="font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">Previous versions</h2>
                  <p><a href="/datasets/{{.DatasetLandingPage.DatasetID}}/editions/{{.DatasetLandingPage.Edition}}/versions">Previous versions</a> of this dataset are available.</p>
               </div>
             </li>


### PR DESCRIPTION
### What
Typography broke CMD styling.
Why? - CMD filterable template is using markdown styling.
Items which were broken and should now be fixed with this PR are:
* Headings are tabbed in
* Subheadings top padding removed
* List styling no longer appearing 'oddly' tabbed

### How to review

1. Checkout this branch and the following for dp-fronted-renderer PR/Branch: https://github.com/ONSdigital/sixteens/pull/149
2. Run the CMD tech stack
3. Check that CMD content pages look as they should
4. Run the standard tech stack
5. Check that Articles (+Neutral), Compendiums and Bulletins still follow the new typography rules

### Who can review

Anyone on the developer team, ideally Frontend Dev except me.