### PR TITLE
Timeseries legacy datasets now show previous versions of a dataset

### DIFF
--- a/assets/templates.go
+++ b/assets/templates.go
@@ -551,7 +551,7 @@ func templatesPartialsHeaderTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/header.tmpl", size: 15132, mode: os.FileMode(420), modTime: time.Unix(1561469191, 0)}
+	info := bindataFileInfo{name: "templates/partials/header.tmpl", size: 15132, mode: os.FileMode(420), modTime: time.Unix(1561469635, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/assets/templates/datasetLandingPage/static.tmpl
+++ b/assets/templates/datasetLandingPage/static.tmpl
@@ -128,6 +128,12 @@
                                 </a>
                             </div>
                         {{ end }}
+                        {{ if $timeseriesDataset.HasVersions }}
+                            <p class="margin-top--0">
+                                <span class="icon icon-info--inline"></span>
+                                <a href="{{ $timeseriesDataset.URI }}" class="underline-link margin-left--3">Previous versions</a> of this data are available.
+                            </p>
+                        {{ end }}
                         {{ if $timeseriesDataset.SupplementaryFiles }}
                             <h4 class="margin-bottom--0">Supporting files you may find useful</h4>
                             <ul class="list--neutral margin-top--0">


### PR DESCRIPTION
### What

Added previous versions to legacy dataset pages rendered via the frontend-renderer, rather than babbage.
<img width="396" alt="Screenshot 2019-06-26 at 12 18 05" src="https://user-images.githubusercontent.com/47502916/60175797-7adf6100-980c-11e9-9038-c9196ca288ad.png">

### How to review

Go to a page like: /economy/inflationandpriceindices/datasets/consumerpriceindices on the ONS website. Note how there are previous versions shows. Now go to the same page but on the beta website. Note this is not shown. This PR should make the previous versions link show if there are previous versions, checkout the branch and confirm this is indeed happening with no side effects

### Who can review

Anyone except me
