### PR TITLE
Fix, docker image to include locale file assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM onsdigital/dp-concourse-tools-ubuntu
 WORKDIR /app/
 
 COPY ./build/dp-frontend-renderer .
-ADD ./assets/locales /app/assets/locales
+COPY ./assets/locales /app/assets/locales
+ADD taxonomy-redirects.yml .
 
 ENTRYPOINT ./dp-frontend-renderer

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ FROM onsdigital/dp-concourse-tools-ubuntu
 WORKDIR /app/
 
 COPY ./build/dp-frontend-renderer .
+ADD ./assets/locales /app/assets/locales
 
 ENTRYPOINT ./dp-frontend-renderer

--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -3,6 +3,7 @@ FROM onsdigital/dp-concourse-tools-ubuntu
 WORKDIR /app/
 
 ADD dp-frontend-renderer .
+ADD ./assets/locales /app/assets/locales
 ADD taxonomy-redirects.yml .
 
 CMD ./dp-frontend-renderer

--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -2,8 +2,6 @@ FROM onsdigital/dp-concourse-tools-ubuntu
 
 WORKDIR /app/
 
-ADD dp-frontend-renderer .
-ADD ./assets/locales /app/assets/locales
-ADD taxonomy-redirects.yml .
+COPY * ./
 
 CMD ./dp-frontend-renderer

--- a/assets/templates.go
+++ b/assets/templates.go
@@ -291,7 +291,7 @@ func templatesDatasetlandingpageStaticTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/datasetLandingPage/static.tmpl", size: 16867, mode: os.FileMode(420), modTime: time.Unix(1565266950, 0)}
+	info := bindataFileInfo{name: "templates/datasetLandingPage/static.tmpl", size: 16867, mode: os.FileMode(420), modTime: time.Unix(1565701492, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -451,7 +451,7 @@ func templatesMainTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/main.tmpl", size: 3131, mode: os.FileMode(420), modTime: time.Unix(1565266950, 0)}
+	info := bindataFileInfo{name: "templates/main.tmpl", size: 3131, mode: os.FileMode(420), modTime: time.Unix(1565701492, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -531,7 +531,7 @@ func templatesPartialsFooterTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/footer.tmpl", size: 4187, mode: os.FileMode(420), modTime: time.Unix(1565266950, 0)}
+	info := bindataFileInfo{name: "templates/partials/footer.tmpl", size: 4187, mode: os.FileMode(420), modTime: time.Unix(1565701492, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -551,7 +551,7 @@ func templatesPartialsHeaderTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/partials/header.tmpl", size: 16422, mode: os.FileMode(420), modTime: time.Unix(1565266950, 0)}
+	info := bindataFileInfo{name: "templates/partials/header.tmpl", size: 16422, mode: os.FileMode(420), modTime: time.Unix(1565701492, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -5,6 +5,8 @@ export GOPATH=$(pwd)/go
 
 pushd $GOPATH/src/github.com/ONSdigital/dp-frontend-renderer
   go build -tags 'production' -o $BINPATH/dp-frontend-renderer
+  mkdir $BINPATH/assets
   cp taxonomy-redirects.yml $BINPATH/
   cp Dockerfile.concourse $BINPATH/
+  cp -r assets/locales $BINPATH/assets/locales
 popd


### PR DESCRIPTION
### What

Although the localisation implementation was working locally. On environments, it uses a docker image and wasn't copying the localisation files across to be used as such it failed to deploy (unhealthy on startup).

### How to review

Change `lang` cookie locally to 'cy' and run the docker image locally. Go to a legacy dataset page, ensure Welsh labels are being shown e.g. Home, search is in Welsh.

### Who can review

Anyone except me