### PR TITLE
updated sixteens version to include js enhancement and decreased padd…

### DIFF
--- a/assets/templates/partials/cookies-banner.tmpl
+++ b/assets/templates/partials/cookies-banner.tmpl
@@ -18,7 +18,7 @@
                 </div>
             </div>
         </div>
-        <div class="cookies-banner__confirmation cookies-banner hidden js-cookies-banner-confirmation" tabindex="-1">
+        <div class="hidden js-cookies-banner-confirmation" tabindex="-1">
             <div class="cookies-banner__wrapper wrapper">
                 <div class="col">
                     <div class="cookies-banner__message adjust-font-size--18">

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/f385917"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/97f6807"
 
 	}
 	return cfg, nil


### PR DESCRIPTION
### What

- Update sixteens version to include js enhancements to the cookies banner
- Decrease padding in cookies success banner

### How to review

- Check sixteens version aligns with most recent commit
- Check that cookies success banner is slimmer - should be `20px` top and bottom padding

### Who can review

Anyone bar me
