### PR TITLE
bump go version to 1.13.8 in CI

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.12.0
+    tag: 1.13.8
 
 inputs:
   - name: dp-frontend-renderer

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.12.0
+    tag: 1.13.8
 
 inputs:
   - name: dp-frontend-renderer


### PR DESCRIPTION
### What

Bump Go version to 1.13.8 

### How to review

Check that all required files are updated to 1.13.8

### Who can review

Anyone but me
