### PR TITLE
Fix/jsonld urls

### DIFF
--- a/assets/templates/partials/json-ld/dataset/filterable.tmpl
+++ b/assets/templates/partials/json-ld/dataset/filterable.tmpl
@@ -9,7 +9,7 @@
         {{ range $i, $el := $data.Version.Downloads }} {
             "@type": "DataDownload",
             "encodingFormat": {{ .Extension }},
-            {{if eq .Extension "txt"}}"contentUrl": {{concatenateStrings $SubDomain $SiteDomain .URI }}{{else}}"contentUrl": {{concatenateStrings .URI}}{{end}}
+            "contentUrl":{{if eq .Extension "txt"}}{{concatenateStrings $SubDomain $SiteDomain .URI }}{{else}}{{concatenateStrings .URI}}{{end}}
             }{{if notLastItem $length $i }},{{end}}
         {{ end }}
         ],

--- a/assets/templates/partials/json-ld/dataset/filterable.tmpl
+++ b/assets/templates/partials/json-ld/dataset/filterable.tmpl
@@ -2,14 +2,14 @@
 {{ $URLPath := .URI }}
 {{ $length := len $data.Version.Downloads }}
 {{ $SiteDomain := .SiteDomain }}
-{{ $SubDomain := "www."}}
-{{ if eq .Language "cy"}}{{$SubDomain = "cy."}}{{end}}
+{{ $SubDomain := "https://www."}}
+{{ if eq .Language "cy"}}{{$SubDomain = "https://cy."}}{{end}}
 {{ if gt $length 0 }}
-        "distribution": [
+    "distribution": [
         {{ range $i, $el := $data.Version.Downloads }} {
             "@type": "DataDownload",
             "encodingFormat": {{ .Extension }},
-            "contentUrl": {{concatenateStrings $SubDomain $SiteDomain .URI }}
+            {{if eq .Extension "txt"}}"contentUrl": {{concatenateStrings $SubDomain $SiteDomain .URI }}{{else}}"contentUrl": {{concatenateStrings .URI}}{{end}}
             }{{if notLastItem $length $i }},{{end}}
         {{ end }}
         ],

--- a/assets/templates/partials/json-ld/dataset/legacy.tmpl
+++ b/assets/templates/partials/json-ld/dataset/legacy.tmpl
@@ -1,8 +1,8 @@
 {{ $data := .DatasetLandingPage }}
 {{ $URLPath := .URI }}
 {{ $SiteDomain := .SiteDomain }}
-{{ $SubDomain := "www."}}
-{{ if eq .Language "cy"}}{{$SubDomain = "cy."}}{{end}}
+{{ $SubDomain := "https://www."}}
+{{ if eq .Language "cy"}}{{$SubDomain = "https://cy."}}{{end}}
     {{ $length := len $data.Datasets }}{{ if gt $length 0 }}
         {{ $latestDataset := index $data.Datasets 0}}
         {{ $numberOfDownloads := len $latestDataset.Downloads }}


### PR DESCRIPTION
### What

The download URLs for filterable pages are inconsistent between the supporting information and the datasets; the latter's `URI` property contains the domain while the supporting information does not. The rendering logic has subsequently been updated to ensure that the URLs displayed in the filterable JSONLD tag are accurate

The protocol has also been prepended to all URLs

### How to review

- Check that the code makes sense
- View a legacy/filterable dataset page and ensure the new URLs look as intended, i.e., include the protocol and in the case of filterable dataset download links do not have the domain prepended twice

### Who can review

Anyone but me
