### PR TITLE
Fix for localisation plurals

### DIFF
--- a/assets/templates/cookies-preferences.tmpl
+++ b/assets/templates/cookies-preferences.tmpl
@@ -15,8 +15,8 @@
     {{if .PreferencesUpdated }}
         <div class="min-height--10 margin-top--4 cookies-banner__preferences-success">
             <div class="font-size--18 cookies-banner__preferences-success-body">
-                <h2 class="font-weight-700 margin-top--2">{{ localise "CookiesPreferencesSaved" .Language 2 }}</h2>
-                <p class="padding-bottom--0 margin-top--1 margin-bottom--1">{{ localise "CookiesPreferencesSavedAmend" .Language 2 | safeHTML }}</p>
+                <h2 class="font-weight-700 margin-top--2">{{ localise "CookiesPreferencesSaved" .Language 4 }}</h2>
+                <p class="padding-bottom--0 margin-top--1 margin-bottom--1">{{ localise "CookiesPreferencesSavedAmend" .Language 4 | safeHTML }}</p>
             </div>
         </div>
     {{end}}
@@ -71,7 +71,7 @@
         
         <p>{{ localise "CookiesEssentialP3" .Language 1 | safeHTML }}</p>
 
-        <button class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-top--2 margin-right--2 font-weight-700 font-size--17 text-wrap cookies-js hidden" type="submit">{{ localise "SaveChanges" .Language 2}}</button>
+        <button class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-top--2 margin-right--2 font-weight-700 font-size--17 text-wrap cookies-js hidden" type="submit">{{ localise "SaveChanges" .Language 4}}</button>
 
     </form>
 </div>

--- a/assets/templates/datasetLandingPage/static.tmpl
+++ b/assets/templates/datasetLandingPage/static.tmpl
@@ -25,7 +25,7 @@
                                 {{ localise "CorrectionsAndNotices" .Language 1  }}
                             {{ else if .DatasetLandingPage.Corrections}}
                                 {{ if (gt (len .DatasetLandingPage.Corrections) 1) }}
-                                    {{ localise "Correction" .Language 2  }}
+                                    {{ localise "Correction" .Language 4  }}
                                 {{ else }}
                                     {{ localise "Correction" .Language 1  }}
                                  {{ end }}

--- a/assets/templates/partials/cookies-banner.tmpl
+++ b/assets/templates/partials/cookies-banner.tmpl
@@ -12,7 +12,7 @@
                     <button class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies" type="submit">{{ localise "CookiesBannerAcceptAllAction" .Language 1 }}</button>
                 </div>
                 <div class="cookies-banner__button">
-                    <a role="button" href="/cookies" class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies">{{ localise "CookiesBannerSetPreferencesAction" .Language 2 }}</a>
+                    <a role="button" href="/cookies" class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies">{{ localise "CookiesBannerSetPreferencesAction" .Language 4 }}</a>
                 </div>
             </div>
         </div>

--- a/assets/templates/partials/footer.tmpl
+++ b/assets/templates/partials/footer.tmpl
@@ -15,7 +15,7 @@
                      </li>
                      {{ if .EnableCookiesControl }}
                         <li class="footer-nav__item">
-                           <a href="/cookies">{{ localise "Cookies" .Language 2 }}</a>
+                           <a href="/cookies">{{ localise "Cookies" .Language 4 }}</a>
                         </li>
                         <li class="footer-nav__item">
                            <a href="/help/privacy">{{ localise "Privacy" .Language 1 }}</a>


### PR DESCRIPTION
### What

The legacy dataset landing pages were not loading due to an error in our templates regarding the way we reference the `Other` key from our localisation files. 

The reason this error wasn't being replicated on different pages that are served by the renderer (/cookies and CMD pages) is because the `Language` property for those pages is empty, thus meaning our `Localise` function defaults to `en` and thus uses the English localisation file. For the legacy dataset landing page, however, the `Language` property was set as `cy` and so is using the Welsh file.

The actual error was regarding the number we use to reference `Other` from within the `Localise` functions called in our templates - such as the Cookies banner and our footer. These keys are based on the [Unicode Common Locale Data Repository (CLDR)](http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html).

Prior to this PR, we were using `2`. In English, this corresponds to `Other`; however, this isn't the case in Welsh.

As such, the template files have been updated so that where we call `Localise` with `2`, we are instead using `4`. This is one of a few numbers that both English and Welsh share in the CLDR that corresponds to `Other`

### How to review

- Ensure that any instances of `Localise` being called with `2` have been updated to `4`
- Check that the pages still load

### Who can review

Describe who worked on the changes, so that other people can review.
