### PR TITLE
Fix/json ld fixes

### DIFF
--- a/assets/templates/partials/json-ld/base.tmpl
+++ b/assets/templates/partials/json-ld/base.tmpl
@@ -1,7 +1,7 @@
 {{$PageData := .}}
 <script type="application/ld+json">
     {
-        "@context": "http://schema.org",
+        "@context": "https://schema.org",
         "name": {{ .Metadata.Title }},
         "publisher": {
         "@type": "GovernmentOrganization",
@@ -14,7 +14,7 @@
             "name": {{ .ContactDetails.Name }}
             },
         {{ end}}
-    "license": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+    "license": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
         {{ if hasField $PageData "DatasetLandingPage" }}
             {{ template "partials/json-ld/dataset/common" . }}
         {{ end }}

--- a/assets/templates/partials/json-ld/dataset/filterable.tmpl
+++ b/assets/templates/partials/json-ld/dataset/filterable.tmpl
@@ -14,6 +14,6 @@
         {{ end }}
         ],
 {{ end }}
-"url": {{ concatenateStrings $SubDomain .SiteDomain "/datasets/" .DatasetId }},
-"datePublished": {{ dateFormat .ReleaseDate }},
+"url": {{ concatenateStrings $SubDomain .SiteDomain "/datasets/" .DatasetId "/editions/" $data.Version.Edition "/versions/" $data.Version.Version  }},
+"datePublished": {{ .ReleaseDate }},
 "description": {{ $data.Version.Description }}

--- a/assets/templates/partials/json-ld/dataset/legacy.tmpl
+++ b/assets/templates/partials/json-ld/dataset/legacy.tmpl
@@ -16,5 +16,5 @@
     ],
     {{ end }}
     "url": {{ concatenateStrings $SubDomain .SiteDomain $URLPath }},
-    "datePublished": {{ dateFormat $data.ReleaseDate }},
+    "datePublished": {{ $data.ReleaseDate }},
     "description": {{ .Metadata.Description }}


### PR DESCRIPTION
### What

Off the back of comments in PO Sign Off, this PR covers the following:

- Removed `dateFormat` method being used in JSON-LD partials. Dates should now be in the ISO8601 format rather than `DD Month YYYY`
- Updated `@context` and `license` to have `https` instead of `http`
- Updated URL for Filterable Dataset page. This now has `/editions/{edition}/versions/{version}` appended

### How to review

- Check code changes make sense
- Load a filterable and legacy dataset landing page and ensure the changes as detailed above have been made

### Who can review

Anyone but me
