### PR TITLE
updated footer to use new OGL logo

### DIFF
--- a/assets/templates/partials/footer.tmpl
+++ b/assets/templates/partials/footer.tmpl
@@ -72,7 +72,7 @@
       </div>
       <div class="wrapper">
          <div class="footer-license">
-            <img class="footer-license__img" alt="OGL" width="60" src="/img/ogl.png">
+            <img class="footer-license__img" alt="OGL" width="60" src="https://cdn.ons.gov.uk/assets/images/logo-ogl-footer.svg">
             <p class="footer-license__text margin-left-sm--0">
                {{ localise "OGLFull" .Language 1 | safeHTML }}
             </p>

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/d0f23c6"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/b07c373"
 
 	}
 	return cfg, nil


### PR DESCRIPTION
### What

The Open Government License (OGL) logo has been updated to match with the new footer typography. We now use an SVG and it is filled with `grey4` - `e2e2e3`

### How to review

Check that the new OGL logo is present in the footer

### Who can review

Anyone but me 
