### PR TITLE
Hide main figures partial while controller/models are WIP

### DIFF
--- a/assets/templates/homepage.tmpl
+++ b/assets/templates/homepage.tmpl
@@ -2,7 +2,7 @@
     {{ template "partials/banners/covid" . }}
     <div class=wrapper>
         <div col-wrap>
-        {{template "partials/homepage/main-figures" .Data }}
+        {{/*  {{template "partials/homepage/main-figures" .Data }} */}}
             <div class="wrapper padding-left--0 padding-right--0 background-gallery">
                 <div class="tiles col-wrap">
                     <div class="tiles__block tiles__block-no-mar-bottom">


### PR DESCRIPTION
### What

The homepage on Develop is currently down because of aspects of the new homepage - specifically the main figures section - require updates to be made in the homepage controller and frontend models that are still WIP. This PR simply comments out the main figures template partial in the interim while we wait for the rest of the main figures work to be implemented in Develop. This will mean the homepage still loads, no errors crop up in the develop alarm channel, and product can sign off other aspects of the homepage in the meantime.

### How to review

Ensure partial is commented out and homepage loads

### Who can review

Anyone but me
