### PR TITLE
Homepage alignment/copy/focus state fixes

### DIFF
--- a/assets/locales/active.cy.toml
+++ b/assets/locales/active.cy.toml
@@ -580,13 +580,13 @@ description = "Discover how our census statistics help paint a picture of the na
 one = "Discover how our census statistics help paint a picture of the nation and how we live."
 
 [InFocus]
-description = "In Focus"
-one = "In Focus"
+description = "In focus"
+one = "In focus"
 
 # Around The ONS - Homepage Section
 [AroundTheONS]
-description = "Around The ONS"
-one = "Around The ONS"
+description = "Around the ONS"
+one = "Around the ONS"
 
 [LocalStatisticsTitle]
 description = "Local statistics"

--- a/assets/locales/active.en.toml
+++ b/assets/locales/active.en.toml
@@ -555,13 +555,13 @@ description = "Discover how our census statistics help paint a picture of the na
 one = "Discover how our census statistics help paint a picture of the nation and how we live."
 
 [InFocus]
-description = "In Focus"
-one = "In Focus"
+description = "In focus"
+one = "In focus"
 
 # Around The ONS - Homepage Section
 [AroundTheONS]
-description = "Around The ONS"
-one = "Around The ONS"
+description = "Around the ONS"
+one = "Around the ONS"
 
 [LocalStatisticsTitle]
 description = "Local statistics"

--- a/assets/templates/homepage.tmpl
+++ b/assets/templates/homepage.tmpl
@@ -4,11 +4,9 @@
         {{template "homepage/main-figures" . }}
         <div class="wrapper padding-left--0 padding-right--0 background-gallery">
             <div class="tiles col-wrap">
-                <div class="tiles__block tiles__block-no-mar-bottom">
-                    <div class="col col--md-23 col--lg-29 background--white margin-left-md--1 margin-bottom--0 margin-top--2">
-                        {{ template "partials/banners/survey" . }}
-                        {{ template "partials/banners/census" . }}
-                    </div>
+                <div class="col col--md-23 col--lg-29 background--white margin-left-md--1 margin-bottom--0 margin-top--2">
+                    {{ template "partials/banners/survey" . }}
+                    {{ template "partials/banners/census" . }}
                 </div>
             </div>
         </div>

--- a/assets/templates/homepage/around-the-ons.tmpl
+++ b/assets/templates/homepage/around-the-ons.tmpl
@@ -8,7 +8,7 @@
                 <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/local-statistics.png">
             </div>
             <h2 class="margin-bottom--0 margin-top--0">
-                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24 underline-link" href="https://www.ons.gov.uk/help/localstatistics">
+                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/help/localstatistics">
                     {{ localise "LocalStatisticsTitle" .Language 4 }}
                 </a>
             </h2>
@@ -21,7 +21,7 @@
                 <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/data-strategy.png">
             </div>
             <h2 class="margin-bottom--0 margin-top--0">
-                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24 underline-link" href="https://www.ons.gov.uk/aboutus/transparencyandgovernance/datastrategy">
+                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/aboutus/transparencyandgovernance/datastrategy">
                     {{ localise "OurDataStrategyTitle" .Language 4 }}
                 </a>
             </h2>
@@ -34,7 +34,7 @@
                 <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/ons-centres.png">
             </div>
             <h2 class="margin-bottom--0 margin-top--0">
-                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24 underline-link" href="https://www.ons.gov.uk/aboutus/whatwedo/programmesandprojects/onscentres">
+                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/aboutus/whatwedo/programmesandprojects/onscentres">
                     {{ localise "ONSCentresTitle" .Language 4 }}
                 </a>
             </h2>
@@ -47,7 +47,7 @@
                 <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/other-govt-statistics.png">
             </div>
             <h2 class="margin-bottom--0 margin-top--0">
-                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24 underline-link" href="https://www.gov.uk/government/statistics">
+                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.gov.uk/government/statistics">
                     {{ localise "OtherGovtStatisticsTitle" .Language 4 }}
                 </a>
             </h2>

--- a/assets/templates/homepage/in-focus.tmpl
+++ b/assets/templates/homepage/in-focus.tmpl
@@ -8,7 +8,7 @@
                 <img class="tile__highlighted-content-image" src="https://static.ons.gov.uk/visual/2020/in-focus/weekly-death-statistics@2x.png">
             </div>
             <h2 class="margin-top--0 margin-bottom--0">
-                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24 underline-link" href="https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/datasets/weeklyprovisionalfiguresondeathsregisteredinenglandandwales">
+                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/datasets/weeklyprovisionalfiguresondeathsregisteredinenglandandwales">
                     Weekly deaths
                 </a>
             </h2>
@@ -21,7 +21,7 @@
                 <img class="tile__highlighted-content-image" src="https://static.ons.gov.uk/visual/2020/in-focus/coronavirus-faster-indicators@2x.png">
             </div>
             <h2 class="margin-top--0 margin-bottom--0">
-                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24 underline-link" href="https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/datasets/weeklyprovisionalfiguresondeathsregisteredinenglandandwales">
+                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/datasets/weeklyprovisionalfiguresondeathsregisteredinenglandandwales">
                     Coronavirus - faster indicators
                 </a>
             </h2>
@@ -34,7 +34,7 @@
                 <img class="tile__highlighted-content-image" src="https://static.ons.gov.uk/visual/2020/in-focus/coronavirus-roundup@2x.png">
             </div>
             <h2 class="margin-top--0 margin-bottom--0">
-                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24 underline-link" href="https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/articles/coronaviruscovid19roundup/2020-03-26">
+                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases/articles/coronaviruscovid19roundup/2020-03-26">
                     Coronavirus roundup
                 </a>
             </h2>
@@ -47,7 +47,7 @@
                 <img class="tile__highlighted-content-image" src="https://static.ons.gov.uk/visual/2020/in-focus/ons-blogs@2x.png">
             </div>
             <h2 class="margin-top--0 margin-bottom--0">
-                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24 underline-link" href="https://blog.ons.gov.uk/category/coronavirus/">
+                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://blog.ons.gov.uk/category/coronavirus/">
                     ONS blogs
                 </a>
             </h2>

--- a/assets/templates/homepage/in-focus.tmpl
+++ b/assets/templates/homepage/in-focus.tmpl
@@ -12,7 +12,7 @@
                     Weekly deaths
                 </a>
             </h2>
-            <p class="tile__highlighted-content-summary margin-top--0">The most up-to-date provisional figures for deaths involving coronavirus (COVID-19) in England and Wales.</p>
+            <p class="tile__highlighted-content-summary margin-top--0">The most up-to-date provisional figures for deaths involving the coronavirus (COVID-19) in England and Wales.</p>
         </article>
     </section>
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">


### PR DESCRIPTION
### What

This PR fixes a few bugs on the homepage:

- Promotional banners in Safari were misaligned with the population tile - the promos were pushed down slightly. This seemed to be caused by superfluous markup that Safari was still parsing, and Firefox/Chrome etc. weren't. The markup has subsequently been removed
- Fixed the titles "In Focus" -> "In focus"; "Around The ONS" -> "Around the ONS" and the copy for "Weekly Deaths" section
- Removed `underline-link` from each of the highlighted content section headings. This ensures that, on `:focus` states, the underline is not present - as per intended design

### How to review

Ensure changes align with description above and that code changes are logical

### Who can review

Anyone but me
