### PR TITLE
Feature/homepage copy changes

### DIFF
--- a/assets/locales/active.cy.toml
+++ b/assets/locales/active.cy.toml
@@ -629,8 +629,8 @@ description ="Latest releases"
 one ="Latest releases"
 
 [OtherReleasesThisWeek]
-description = "others releases this week"
-one = "others releases this week"
+description = "other releases this week"
+one = "other releases this week"
 
 [AllReleases]
 description = "All of our releases by date"

--- a/assets/locales/active.en.toml
+++ b/assets/locales/active.en.toml
@@ -604,8 +604,8 @@ description ="Latest releases"
 one ="Latest releases"
 
 [OtherReleasesThisWeek]
-description = "others releases this week"
-one = "others releases this week"
+description = "other releases this week"
+one = "other releases this week"
 
 [AllReleases]
 description = "All of our releases by date"

--- a/assets/templates/homepage/latest-releases.tmpl
+++ b/assets/templates/homepage/latest-releases.tmpl
@@ -16,11 +16,11 @@
             </li>
         {{ end }}
     </ul>
-    <p class="tile__content margin-top--0 margin-bottom--0 font-size--18">{{ subtract .Data.ReleaseCalendar.NumberOfReleases $releasesLen }} {{ localise "OtherReleasesThisWeek" .Language 1 }}</p>
+    <p class="tile__content tile__subheading margin-top--0 margin-bottom--0 font-size--18">{{ subtract .Data.ReleaseCalendar.NumberOfReleases $releasesLen }} {{ localise "OtherReleasesThisWeek" .Language 1 }}</p>
     {{ else }}
     <p class="tile__content margin-top--0 margin-bottom--0 font-size--18">No releases</p>
     {{ end }}
-    <p class="margin-top--0 margin-bottom--0">
+    <p class="margin-top--0 margin-bottom--0 padding-bottom--0">
         <a class="tile__link font-weight-700" href="/releasecalendar">{{ localise "AllReleases" .Language 1 }}</a>
     </p>
 </article>

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -13,19 +13,13 @@
     </header>
     <!--desktop-->
     <div class="hide--sm hide--md-only">
-        <article class="col col--lg-29 col--md-29 tile margin-right--1">
-            <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment rate</span></h2></header>
-            <div class="margin-top-md--2 margin-top-lg--2">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})
-            </div>
-            <section class="col col--lg-12 col--md-12">
-                <div class="margin-top--1">Employed</div>
+        <article class="col col--lg-29 col--md-29 tile margin-right--1 height--53">
+            <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment</span></h2></header>
+            <section class="col col--lg-12 col--md-12 margin-right--1">
+                <div class="margin-top--1 tile__subheading">Employment rate</div>
+                <div class="margin-top-md--2 margin-top-lg--1">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                 <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
                 <p class="tile__trend">
-                    <span class="tile__trend__icon">
-                        {{if $EmploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                        {{if $EmploymentRate.Trend.IsDown}}&darr;{{ end }}
-                        {{if $EmploymentRate.Trend.IsFlat}}={{ end }}
-                    </span>
                     <span class="tile__trend__text">{{ $EmploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $EmploymentRate.Trend.Period }}</span>
                 </p>
                 <div class="margin-top--2">
@@ -34,15 +28,11 @@
                 </div>
             </section>
             <div class="col tile__split-bar print--hide hide--md hide--lg"></div>
-            <section class="col padding-left-lg--2 padding-left-md--2 col--lg-12 col--md-12">
-                <div class="margin-top--1">Unemployed</div>
+            <section class="col margin-left--1 col--lg-12 col--md-12">
+                <div class="margin-top--1 tile__subheading">Unemployment rate</div>
+                <div class="margin-top-md--2 margin-top-lg--1">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                 <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
                 <p class="tile__trend">
-                    <span class="tile__trend__icon">
-                        {{if $UnemploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                        {{if $UnemploymentRate.Trend.IsDown}}&darr;{{ end }}
-                        {{if $UnemploymentRate.Trend.IsFlat}}={{ end }}
-                    </span>
                     <span class="tile__trend__text">{{ $UnemploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $UnemploymentRate.Trend.Period }}</span>
                 </p>
                 <div class="margin-top--2">
@@ -51,17 +41,12 @@
                 </div>
             </section>
         </article>
-        <article class="tile tile__content col col--lg-14 col--md-14 margin-right--1">
+        <article class="tile tile__content col col--lg-14 col--md-14 margin-right--1 height--53">
             <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Inflation</span></h2></header>
-            <div class="margin-top--2">CPIH 12-month rate</div>
+            <div class="margin-top--1">CPIH 12-month rate</div>
             <div class="margin-top--1">{{ DatePeriodFormat $Inflation.Date }}</div>
             <div class="tile__figure">{{ $Inflation.Figure }}{{ $Inflation.Unit }}</div>
             <p class="tile__trend">
-                <span class="tile__trend__icon">
-                    {{if $Inflation.Trend.IsUp}}&uarr;{{ end }}
-                    {{if $Inflation.Trend.IsDown}}&darr;{{ end }}
-                    {{if $Inflation.Trend.IsFlat}}={{ end }}
-                </span>
                 <span class="tile__trend__text">{{ $Inflation.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $Inflation.Trend.Period }}</span>
             </p>
             <div class="margin-top--2">
@@ -69,17 +54,12 @@
                 <a href="{{ $Inflation.FigureURIs.Data }}" class="tile__link margin-left--1">Data</a>
             </div>
         </article>
-        <article class="tile tile__content col col--lg-14 col--md-14 margin-top-md--2 margin-top-lg--2">
+        <article class="tile tile__content col col--lg-14 col--md-14 margin-top-md--2 margin-top-lg--2 height--53">
             <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">GDP</span></h2></header>
-            <div class="margin-top--2">Quarter on Quarter</div>
+            <div class="margin-top--1">Quarter on Quarter</div>
             <div class="margin-top--1">{{ DatePeriodFormat $GDP.Date }}</div>
             <div class="tile__figure">{{ $GDP.Figure }}{{ $GDP.Unit}}</div>
             <p class="tile__trend">
-                <span class="tile__trend__icon">
-                    {{if $GDP.Trend.IsUp}}&uarr;{{ end }}
-                    {{if $GDP.Trend.IsDown}}&darr;{{ end }}
-                    {{if $GDP.Trend.IsFlat}}={{ end }}
-                </span>
                 <span class="tile__trend__text">{{ $GDP.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $GDP.Trend.Period }}</span>
             </p>
             <div class="margin-top--2">

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -103,7 +103,7 @@
     </div>
     <!--medium-->
     <div class="col-wrap hide--sm hide--lg">
-        <div class="col col--md-17">
+        <div class="col col--md-18">
             <article class="tile margin-left--1">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment</span></h2></header>
                 <section class="col col--md-12">

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -247,11 +247,10 @@
                 </div>
             </article>
             <article class="col tile margin-right--1">
-                <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment rate</span></h2></header>
-                <div class="">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date }})
-                </div>
+                <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment</span></h2></header>
                 <section class="col">
-                    <div class="margin-top--1"><b>Employed</b></div>
+                    <div class="margin-top--1 tile__subheading"><b>Employment rate</b></div>
+                    <div class="">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date }})</div>
                     <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
                     <p class="tile__trend">
                         <span class="tile__trend__icon">
@@ -268,7 +267,8 @@
                 </section>
                 <div class="col tile__split-bar"></div>
                 <div class="col">
-                    <div class="margin-top--1"><b>Unemployed</b></div>
+                    <div class="margin-top--1 tile__subheading"><b>Unemployment rate</b></div>
+                    <div class="">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date }})</div>
                     <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
                     <p class="tile__trend">
                         <span class="tile__trend__icon">

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -71,7 +71,7 @@
         <div class="col col--lg-29 col--md-29">
             <article class="tile tile__content margin-top-lg--2 margin-top-md--2 margin-left-md--1 margin-left-lg--0">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">UK population</span></h2></header>
-                <div class="margin-top--2">Mid-year estimate ({{ DatePeriodFormat $Population.Date }})</div>
+                <div class="margin-top--1">Mid-year estimate ({{ DatePeriodFormat $Population.Date }})</div>
                 <div class="tile__figure">{{ $Population.Figure }}</div>
                 <div class="margin-top--2">
                     <a href="{{ $Population.FigureURIs.Analysis}}" class="tile__link">Analysis</a>
@@ -86,17 +86,11 @@
         <div class="col col--md-17">
             <article class="tile margin-left--1">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment</span></h2></header>
-                <div class="margin-top-md--2">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})
-                </div>
                 <section class="col col--md-12">
-                    <div class="margin-top--1">Employed</div>
+                    <div class="margin-top--1 tile__subheading">Employment rate</div>
+                    <div class="margin-top-md--2">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                     <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
                     <p class="tile__trend">
-                        <span class="tile__trend__icon">
-                            {{if $EmploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                            {{if $EmploymentRate.Trend.IsDown}}&darr;{{ end }}
-                            {{if $EmploymentRate.Trend.IsFlat}}={{ end }}
-                        </span>
                         <span class="tile__trend__text">{{ $EmploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $EmploymentRate.Trend.Period }}</span>
                     </p>
                     <div class="margin-top--2">
@@ -106,7 +100,8 @@
                 </section>
                 <div class="col tile__split-bar print--hide width-md--14 margin-left-md--0 margin-top-md--3"></div>
                 <section class="col col--md-12">
-                    <div class="margin-top--1">Unemployed</div>
+                    <div class="margin-top--1 tile__subheading">Unemployment rate</div>
+                    <div class="margin-top-md--2">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                     <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
                     <p class="tile__trend">
                         <span class="tile__trend__icon">
@@ -127,7 +122,7 @@
             </div>
         </div>
         <div class="col col--md-30">
-            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2">
+            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2 height-md--53">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Inflation</span></h2></header>
                 <div class="margin-top--2">CPIH 12-month rate</div>
                 <div class="margin-top--1">{{ DatePeriodFormat $Inflation.Date }}</div>
@@ -145,7 +140,7 @@
                     <a href="{{ $Inflation.FigureURIs.Data }}" class="tile__link margin-left--1">Data</a>
                 </div>
             </article>
-            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2">
+            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2 height-md--53">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">GDP</span></h2></header>
                 <div class="margin-top--2">Quarter on Quarter</div>
                 <div class="margin-top--1">{{ DatePeriodFormat $GDP.Date }}</div>

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -20,6 +20,11 @@
                 <div class="margin-top-md--2 margin-top-lg--1">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                 <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
                 <p class="tile__trend">
+                    <span class="tile__trend__icon">
+                        {{if $EmploymentRate.Trend.IsUp}}&uarr;{{ end }}
+                        {{if $EmploymentRate.Trend.IsDown}}&darr;{{ end }}
+                        {{if $EmploymentRate.Trend.IsFlat}}={{ end }}
+                    </span>
                     <span class="tile__trend__text">{{ $EmploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $EmploymentRate.Trend.Period }}</span>
                 </p>
                 <div class="margin-top--2">
@@ -33,6 +38,11 @@
                 <div class="margin-top-md--2 margin-top-lg--1">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                 <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
                 <p class="tile__trend">
+                    <span class="tile__trend__icon">
+                        {{if $UnemploymentRate.Trend.IsUp}}&uarr;{{ end }}
+                        {{if $UnemploymentRate.Trend.IsDown}}&darr;{{ end }}
+                        {{if $UnemploymentRate.Trend.IsFlat}}={{ end }}
+                    </span>
                     <span class="tile__trend__text">{{ $UnemploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $UnemploymentRate.Trend.Period }}</span>
                 </p>
                 <div class="margin-top--2">
@@ -47,6 +57,11 @@
             <div class="margin-top--1">{{ DatePeriodFormat $Inflation.Date }}</div>
             <div class="tile__figure">{{ $Inflation.Figure }}{{ $Inflation.Unit }}</div>
             <p class="tile__trend">
+                <span class="tile__trend__icon">
+                    {{if $Inflation.Trend.IsUp}}&uarr;{{ end }}
+                    {{if $Inflation.Trend.IsDown}}&darr;{{ end }}
+                    {{if $Inflation.Trend.IsFlat}}={{ end }}
+                </span>            
                 <span class="tile__trend__text">{{ $Inflation.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $Inflation.Trend.Period }}</span>
             </p>
             <div class="margin-top--2">
@@ -60,6 +75,11 @@
             <div class="margin-top--1">{{ DatePeriodFormat $GDP.Date }}</div>
             <div class="tile__figure">{{ $GDP.Figure }}{{ $GDP.Unit}}</div>
             <p class="tile__trend">
+                <span class="tile__trend__icon">
+                    {{if $GDP.Trend.IsUp}}&uarr;{{ end }}
+                    {{if $GDP.Trend.IsDown}}&darr;{{ end }}
+                    {{if $GDP.Trend.IsFlat}}={{ end }}
+                </span>   
                 <span class="tile__trend__text">{{ $GDP.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $GDP.Trend.Period }}</span>
             </p>
             <div class="margin-top--2">
@@ -91,6 +111,11 @@
                     <div class="margin-top-md--2">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                     <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
                     <p class="tile__trend">
+                        <span class="tile__trend__icon">
+                            {{if $EmploymentRate.Trend.IsUp}}&uarr;{{ end }}
+                            {{if $EmploymentRate.Trend.IsDown}}&darr;{{ end }}
+                            {{if $EmploymentRate.Trend.IsFlat}}={{ end }}
+                        </span>
                         <span class="tile__trend__text">{{ $EmploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $EmploymentRate.Trend.Period }}</span>
                     </p>
                     <div class="margin-top--2">

--- a/assets/templates/homepage/promos.tmpl
+++ b/assets/templates/homepage/promos.tmpl
@@ -1,6 +1,6 @@
 <div class="wrapper padding-left--0 padding-right--0 background-gallery">
     <div class="tiles col-wrap">
-        <div class="col col--md-16 col--lg-29 background--white margin-left-md--2 margin-left-lg--1 margin-bottom--0 margin-top--2">
+        <div class="col col--md-17 col--lg-29 background--white margin-left-md--2 margin-left-lg--1 margin-bottom--0 margin-top--2">
             {{ template "partials/banners/survey" . }}
             {{ template "partials/banners/census" . }}
         </div>

--- a/assets/templates/partials/banners/census.tmpl
+++ b/assets/templates/partials/banners/census.tmpl
@@ -1,5 +1,5 @@
 <a class="promo__container" href="/census">
-    <section class="promo__background--plum-gradient box__content box__content--homepage height-sm--18 height-md--25 height-lg--16 padding-top-sm--3 padding-top-md--5 padding-top-lg--2 margin-bottom--2">
+    <section class="promo__background--plum-gradient box__content box__content--homepage height-sm--18 height-md--25 height-lg--16 padding-top-sm--3 padding-top-md--2 padding-top-lg--2 margin-bottom--2">
         <div class="promo__copy promo__body--column padding-left--1">
             <img class="padding-top--1 width-md--13 padding-bottom-md--1" alt="Census 2021" src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape.svg">
             <p class="padding-top--1 promo__description margin-top--0 margin-bottom--0 padding-right--1 padding-top--0 underline-link">

--- a/assets/templates/partials/banners/census.tmpl
+++ b/assets/templates/partials/banners/census.tmpl
@@ -1,5 +1,5 @@
 <a class="promo__container" href="/census">
-    <section class="promo__background--plum-gradient box__content box__content--homepage height-sm--18 height-md--27 height-lg--16 padding-top-sm--2 padding-top-md--2 padding-top-lg--2 margin-bottom--2">
+    <section class="promo__background--plum-gradient box__content box__content--homepage height-sm--18 height-md--25 height-lg--16 padding-top-sm--3 padding-top-md--5 padding-top-lg--2 margin-bottom--2">
         <div class="promo__copy promo__body--column padding-left--1">
             <img class="padding-top--1 width-md--13 padding-bottom-md--1" alt="Census 2021" src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape.svg">
             <p class="padding-top--1 promo__description margin-top--0 margin-bottom--0 padding-right--1 padding-top--0 underline-link">

--- a/assets/templates/partials/banners/survey.tmpl
+++ b/assets/templates/partials/banners/survey.tmpl
@@ -1,5 +1,5 @@
 <a class="promo__container" href="/surveys">
-    <section class="promo__background--blue-gradient box__content box__content--homepage height-sm--14 height-md--27 height-lg--14 margin-bottom--2">
+    <section class="promo__background--blue-gradient box__content box__content--homepage height-sm--14 height-md--22 height-lg--14 margin-bottom--2 padding-top-md--1">
         <div class="promo__body padding-right--1 padding-top-md--2">
             <img class="hide--md-only" src="https://cdn.ons.gov.uk/assets/images/icon-checkbox.svg">
             <div class="promo__copy">

--- a/assets/templates/partials/banners/survey.tmpl
+++ b/assets/templates/partials/banners/survey.tmpl
@@ -1,5 +1,5 @@
 <a class="promo__container" href="/surveys">
-    <section class="promo__background--blue-gradient box__content box__content--homepage height-sm--14 height-md--22 height-lg--14 margin-bottom--2 padding-top-md--1">
+    <section class="promo__background--blue-gradient box__content box__content--homepage height-sm--14 height-md--22 height-lg--14 margin-bottom--2">
         <div class="promo__body padding-right--1 padding-top-md--2">
             <img class="hide--md-only" src="https://cdn.ons.gov.uk/assets/images/icon-checkbox.svg">
             <div class="promo__copy">


### PR DESCRIPTION
### What

Updated the wording for the Main figures tiles as per the Trello [ticket](https://trello.com/c/zJAB7h8f/211-homepage-adjustments-to-main-figures-wording-3).

Some styling changes have also been applied in order for the layouts to still match and align properly. Equalising the heights on the `lg` and `md` viewports has been achieved by using the `height--53` utility class

### How to review

Run the homepage with the `feature/tile-styling-updates` Sixteens branch running as well as `feature/update-main-figures-period-wording` for the Homepage Controller.

Check that the updated wording aligns with the requirements in the Trello ticket.

Check that the general layout is there across viewport sizes.

Browser compatibility has been checked (IE11 via Browserstack) but no harm in doing a second look through.

### Who can review

Anyone but me
