### PR TITLE
add modifier class to set latest releases to a fixed height

### DIFF
--- a/assets/templates/homepage/latest-releases.tmpl
+++ b/assets/templates/homepage/latest-releases.tmpl
@@ -1,7 +1,7 @@
 {{ $releases := .Data.ReleaseCalendar.Releases }}
 {{ $releasesLen := len .Data.ReleaseCalendar.Releases }}
 
-<article class="tile tile__content col col--lg-29 col--md-29 margin-top-lg--2 margin-top-md--2 margin-left-md--1 margin-left-lg--1">
+<article class="tile tile--latest-releases tile__content col col--lg-29 col--md-29 margin-top-lg--2 margin-top-md--2 margin-left-md--1 margin-left-lg--1">
     <header class="margin-top--1">
         <h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0">
             <span class="tile__title">{{ localise "LatestReleases" .Language 1 }}</span>

--- a/assets/templates/homepage/latest-releases.tmpl
+++ b/assets/templates/homepage/latest-releases.tmpl
@@ -12,7 +12,7 @@
         {{range $releases}}
             <li class="tile__list-item">
                 <a href="{{ .URI }}" class="tile__link tile__list-item-title">{{ .Title }}</a>
-                <p class="tile__list-item-content margin-top--0 margin-bottom--0">{{ .ReleaseDate }}</p>
+                <p class="tile__list-item-content margin-top--0 margin-bottom--0 padding-top--0">{{ .ReleaseDate }}</p>
             </li>
         {{ end }}
     </ul>

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/a310eb3"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/6a9b674"
 
 	}
 	return cfg, nil


### PR DESCRIPTION
### What

- Added a modifier class `tile--latest-releases` to the latest releases tile. This ensures that the latest releases has a fixed height which ensures it aligns with the bottom of the Census promo banner in md/lg viewport sizes.

### How to review

- Class name matches
- Check that the latest releases tile aligns with the bottom of the promo banners

### Who can review

Anyone but me
