### PR TITLE
removed class that generates css ellipsis

### DIFF
--- a/assets/templates/homepage/latest-releases.tmpl
+++ b/assets/templates/homepage/latest-releases.tmpl
@@ -11,7 +11,7 @@
     <ul class="tile__list list--neutral margin-bottom--0">
         {{range $releases}}
             <li class="tile__list-item margin-bottom--2">
-                <a href="{{ .URI }}" class="tile__link tile__list-item-title">{{ truncateToMaximumCharacters .Title 96 }}</a>
+                <a href="{{ .URI }}" class="tile__link">{{ truncateToMaximumCharacters .Title 96 }}</a>
                 <p class="tile__list-item-content margin-top--0 margin-bottom--0 padding-top--0">{{ .ReleaseDate }}</p>
             </li>
         {{ end }}


### PR DESCRIPTION
### What

Removed the ellipsis css class as that is no longer used owing to truncation happening in the Renderer.

### How to review

Check that `tile__list-item-title` class is removed

### Who can review

Anyone but me
