### PR TITLE
implemented cookies-banner--hidden class to fix jitter bug issue

### DIFF
--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -55,7 +55,7 @@
     <!-- End Google Tag Manager -->
 </head>
 <body class="{{ .Type }}">
-
+<script>document.body.className = ((document.body.className) ? document.body.className + ' js' : 'js');</script>
   <!-- Google Tag Manager (noscript) -->
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MBCBVQS"
                     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>

--- a/assets/templates/partials/banners/cookies.tmpl
+++ b/assets/templates/partials/banners/cookies.tmpl
@@ -1,5 +1,5 @@
-<form action="/cookies/accept-all" method="GET" id="global-cookie-message" class="cookies-banner js-cookies-banner-form clearfix"
-            aria-label="cookie banner" style="display: block;">
+<form action="/cookies/accept-all" method="GET" id="global-cookie-message" class="cookies-banner cookies-banner--hidden js-cookies-banner-form clearfix"
+            aria-label="cookie banner">
     <div class="cookies-banner__wrapper wrapper js-cookies-banner-inform">
         <div>
             <div class="cookies-banner__message adjust-font-size--18">

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/6a9b674"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/c9680eb"
 
 	}
 	return cfg, nil


### PR DESCRIPTION
### What

This PR adds  a script tag which appends a `js` class to the body tag (i.e., to signify that JavaScript is enabled). This will allow us to implement certain JS-specific interactivity. In this case, it fixes a jitter bug we had with the cookies banner rendering on refresh.

### How to review

Check the code changes make sense. Should include updated sixteens path, a change to add the script in the main template file, and another to add `cookies-banner--hidden` class which is where the functionality is implemented

### Who can review

Anyone but me
