### PR TITLE
Feature/updated homepage layout

### DIFF
--- a/assets/locales/active.cy.toml
+++ b/assets/locales/active.cy.toml
@@ -645,5 +645,5 @@ description = "other releases this week"
 one = "other releases this week"
 
 [AllReleases]
-description = "All of our releases by date"
-one = "All of our releases by date"
+description = "View all of our releases by date"
+one = "View all of our releases by date"

--- a/assets/locales/active.cy.toml
+++ b/assets/locales/active.cy.toml
@@ -576,8 +576,8 @@ description = "Get the latest data and analysis on coronavirus (COVID-19) in the
 one = "Y data a’r dadansoddiad diweddaraf ar y coronafeirws."
 
 [CensusBannerBody]
-description = "Discover how our census statistics help paint a picture of the nation and how we live."
-one = "Discover how our census statistics help paint a picture of the nation and how we live."
+description = "Help paint a picture of the nation and how we live."
+one = "Help paint a picture of the nation and how we live."
 
 [InFocus]
 description = "In focus"

--- a/assets/locales/active.cy.toml
+++ b/assets/locales/active.cy.toml
@@ -628,6 +628,18 @@ one = "on previous"
 description ="Latest releases"
 one ="Latest releases"
 
+[ReleaseCalendarTileInfo]
+description = "All of our publications are listed in our release calendar."
+one = "All of our publications are listed in our release calendar."
+
+[ReleaseCalendarTilePublicationCount]
+description = "We have published"
+one = "We have published"
+
+[ReleaseCalendarTilePublicationPeriod]
+description = " statistical releases in the last 7 days."
+one = " statistical releases in the last 7 days."
+
 [OtherReleasesThisWeek]
 description = "other releases this week"
 one = "other releases this week"

--- a/assets/locales/active.en.toml
+++ b/assets/locales/active.en.toml
@@ -551,8 +551,8 @@ description = "Get the latest data and analysis on coronavirus (COVID-19) in the
 one = "Get the latest data and analysis on coronavirus (COVID-19) in the UK."
 
 [CensusBannerBody]
-description = "Discover how our census statistics help paint a picture of the nation and how we live."
-one = "Discover how our census statistics help paint a picture of the nation and how we live."
+description = "Help paint a picture of the nation and how we live."
+one = "Help paint a picture of the nation and how we live."
 
 [InFocus]
 description = "In focus"

--- a/assets/locales/active.en.toml
+++ b/assets/locales/active.en.toml
@@ -620,5 +620,5 @@ description = "other releases this week"
 one = "other releases this week"
 
 [AllReleases]
-description = "All of our releases by date"
-one = "All of our releases by date"
+description = "View all of our releases by date"
+one = "View all of our releases by date"

--- a/assets/locales/active.en.toml
+++ b/assets/locales/active.en.toml
@@ -603,6 +603,18 @@ one = "on previous"
 description ="Latest releases"
 one ="Latest releases"
 
+[ReleaseCalendarTileInfo]
+description = "All of our publications are listed in our release calendar."
+one = "All of our publications are listed in our release calendar."
+
+[ReleaseCalendarTilePublicationCount]
+description = "We have published"
+one = "We have published"
+
+[ReleaseCalendarTilePublicationPeriod]
+description = " statistical releases in the last 7 days."
+one = " statistical releases in the last 7 days."
+
 [OtherReleasesThisWeek]
 description = "other releases this week"
 one = "other releases this week"

--- a/assets/templates/homepage.tmpl
+++ b/assets/templates/homepage.tmpl
@@ -3,9 +3,11 @@
     <div class="wrapper">
         {{ template "homepage/main-figures" . }}
 
-        <div class="hide--md-only">
+        <div>
             {{ template "homepage/latest-releases" . }}
         </div>
+        {{ template "homepage/promos" . }}
+
     </div>
     <div class="wrapper background-gallery">
         <div class="tiles col-wrap">

--- a/assets/templates/homepage/around-the-ons.tmpl
+++ b/assets/templates/homepage/around-the-ons.tmpl
@@ -12,7 +12,7 @@
                     {{ localise "LocalStatisticsTitle" .Language 4 }}
                 </a>
             </h2>
-            <p class="tile__highlighted-content-summary margin-top--0">{{ localise "LocalStatisticsSummary" .Language 4 }}</p>
+            <p class="tile__text-description margin-top--0">{{ localise "LocalStatisticsSummary" .Language 4 }}</p>
         </article>
     </section>
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
@@ -25,7 +25,7 @@
                     {{ localise "OurDataStrategyTitle" .Language 4 }}
                 </a>
             </h2>
-            <p class="tile__highlighted-content-summary margin-top--0">{{ localise "OurDataStrategySummary" .Language 4 }}</p>
+            <p class="tile__text-description margin-top--0">{{ localise "OurDataStrategySummary" .Language 4 }}</p>
         </article>
     </section>
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
@@ -38,7 +38,7 @@
                     {{ localise "ONSCentresTitle" .Language 4 }}
                 </a>
             </h2>
-            <p class="tile__highlighted-content-summary margin-top--0">{{ localise "ONSCentresSummary" .Language 4 }}</p>
+            <p class="tile__text-description margin-top--0">{{ localise "ONSCentresSummary" .Language 4 }}</p>
         </article>
     </section>
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
@@ -51,7 +51,7 @@
                     {{ localise "OtherGovtStatisticsTitle" .Language 4 }}
                 </a>
             </h2>
-            <p class="tile__highlighted-content-summary margin-top--0">{{ localise "OtherGovtStatisticsSummary" .Language 4 }}</p>
+            <p class="tile__text-description margin-top--0">{{ localise "OtherGovtStatisticsSummary" .Language 4 }}</p>
         </article>
     </section>
 </section>

--- a/assets/templates/homepage/in-focus.tmpl
+++ b/assets/templates/homepage/in-focus.tmpl
@@ -12,7 +12,7 @@
                     Weekly deaths
                 </a>
             </h2>
-            <p class="tile__highlighted-content-summary margin-top--0">The most up-to-date provisional figures for deaths involving the coronavirus (COVID-19) in England and Wales.</p>
+            <p class="tile__text-description margin-top--0">The most up-to-date provisional figures for deaths involving the coronavirus (COVID-19) in England and Wales.</p>
         </article>
     </section>
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
@@ -25,7 +25,7 @@
                     Coronavirus - faster indicators
                 </a>
             </h2>
-            <p class="tile__highlighted-content-summary margin-top--0">The latest data and experimental indicators on the UK economy and society.</p>
+            <p class="tile__text-description margin-top--0">The latest data and experimental indicators on the UK economy and society.</p>
         </article>
     </section>
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
@@ -38,7 +38,7 @@
                     Coronavirus roundup
                 </a>
             </h2>
-            <p class="tile__highlighted-content-summary margin-top--0">Our summary of the latest data and analysis related to the coronavirus pandemic.</p>
+            <p class="tile__text-description margin-top--0">Our summary of the latest data and analysis related to the coronavirus pandemic.</p>
         </article>
     </section>
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
@@ -51,7 +51,7 @@
                     ONS blogs
                 </a>
             </h2>
-            <p class="tile__highlighted-content-summary margin-top--0">Find out more about the work ONS is doing to respond to the challenge of the pandemic.</p>
+            <p class="tile__text-description margin-top--0">Find out more about the work ONS is doing to respond to the challenge of the pandemic.</p>
         </article>
     </section>
 </section>

--- a/assets/templates/homepage/latest-releases.tmpl
+++ b/assets/templates/homepage/latest-releases.tmpl
@@ -8,7 +8,7 @@
         </h2>
     </header>
     <div class="tile__content-container--space-between">
-        <p class="tile__content margin-top--0 margin-bottom--0 font-size--18">
+        <p class="tile__content tile__text-description margin-top--0 margin-bottom--0 font-size--18">
         {{ localise "ReleaseCalendarTileInfo" .Language 1 }} {{ localise "ReleaseCalendarTilePublicationCount" .Language 1 }} 
         {{ .Data.ReleaseCalendar.NumberOfReleases }} {{ localise "ReleaseCalendarTilePublicationPeriod" .Language 1 }}
         </p>

--- a/assets/templates/homepage/latest-releases.tmpl
+++ b/assets/templates/homepage/latest-releases.tmpl
@@ -1,7 +1,7 @@
 {{ $releases := .Data.ReleaseCalendar.Releases }}
 {{ $releasesLen := len .Data.ReleaseCalendar.Releases }}
 
-<article class="tile tile--latest-releases tile__content col col--lg-29 margin-top-lg--2 margin-top-md--2 margin-left-lg--1">
+<article class="tile tile__content col col--lg-29 margin-top-lg--2 margin-top-md--2 margin-left-lg--1 height-lg--31">
     <header class="margin-top--1">
         <h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0">
             <span class="tile__title">{{ localise "LatestReleases" .Language 1 }}</span>

--- a/assets/templates/homepage/latest-releases.tmpl
+++ b/assets/templates/homepage/latest-releases.tmpl
@@ -7,20 +7,13 @@
             <span class="tile__title">{{ localise "LatestReleases" .Language 1 }}</span>
         </h2>
     </header>
-    {{ if gt $releasesLen 0 }}
-    <ul class="tile__list list--neutral margin-bottom--0">
-        {{range $releases}}
-            <li class="tile__list-item margin-bottom--2">
-                <a href="{{ .URI }}" class="tile__link">{{ truncateToMaximumCharacters .Title 96 }}</a>
-                <p class="tile__list-item-content margin-top--0 margin-bottom--0 padding-top--0">{{ .ReleaseDate }}</p>
-            </li>
-        {{ end }}
-    </ul>
-    <p class="tile__content tile__subheading margin-top--0 margin-bottom--0 font-size--18">{{ .Data.ReleaseCalendar.NumberOfOtherReleasesInSevenDays }} {{ localise "OtherReleasesThisWeek" .Language 1 }}</p>
-    {{ else }}
-    <p class="tile__content margin-top--0 margin-bottom--0 font-size--18">No releases</p>
-    {{ end }}
-    <p class="margin-top--0 margin-bottom--0 padding-bottom--0">
-        <a class="tile__link font-weight-700" href="/releasecalendar">{{ localise "AllReleases" .Language 1 }}</a>
-    </p>
+    <div class="tile__content-container--space-between">
+        <p class="tile__content margin-top--0 margin-bottom--0 font-size--18">
+        {{ localise "ReleaseCalendarTileInfo" .Language 1 }} {{ localise "ReleaseCalendarTilePublicationCount" .Language 1 }} 
+        {{ .Data.ReleaseCalendar.NumberOfReleases }} {{ localise "ReleaseCalendarTilePublicationPeriod" .Language 1 }}
+        </p>
+        <p class="margin-top--0 margin-bottom--0 padding-bottom--0">
+            <a class="tile__link" href="/releasecalendar">{{ localise "AllReleases" .Language 1 }}</a>
+        </p>
+    </div>
 </article>

--- a/assets/templates/homepage/latest-releases.tmpl
+++ b/assets/templates/homepage/latest-releases.tmpl
@@ -1,7 +1,7 @@
 {{ $releases := .Data.ReleaseCalendar.Releases }}
 {{ $releasesLen := len .Data.ReleaseCalendar.Releases }}
 
-<article class="tile tile--latest-releases tile__content col col--lg-29 col--md-29 margin-top-lg--2 margin-top-md--2 margin-left-md--1 margin-left-lg--1">
+<article class="tile tile--latest-releases tile__content col col--lg-29 margin-top-lg--2 margin-top-md--2 margin-left-lg--1">
     <header class="margin-top--1">
         <h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0">
             <span class="tile__title">{{ localise "LatestReleases" .Language 1 }}</span>

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -89,7 +89,7 @@
 
         </article>
         <div class="col col--lg-29 col--md-29">
-            <article class="tile tile__content margin-top-lg--2 margin-top-md--2 margin-left-md--1 margin-left-lg--0">
+            <article class="tile tile__content margin-top-lg--2 margin-top-md--2 margin-left-md--1 margin-left-lg--0 height-lg--31">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">UK population</span></h2></header>
                 <div class="margin-top--1">Mid-year estimate ({{ DatePeriodFormat $Population.Date }})</div>
                 <div class="tile__figure">{{ $Population.Figure }}</div>
@@ -103,10 +103,10 @@
     <!--medium-->
     <div class="col-wrap hide--sm hide--lg">
         <div class="col col--md-18">
-            <article class="tile margin-left--1">
+            <article class="tile tile--employment-figures-stacked margin-left--1">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment</span></h2></header>
                 <section class="col col--md-12">
-                    <div class="margin-top--1 tile__subheading">Employment rate</div>
+                    <div class="margin-top--2 tile__subheading">Employment rate</div>
                     <div class="margin-top-md--2">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                     <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
                     <p class="tile__trend">
@@ -143,7 +143,7 @@
             </article>
         </div>
         <div class="col col--md-30">
-            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2 height-md--55">
+            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2 height-md--56">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Inflation</span></h2></header>
                 <div class="margin-top--2">CPIH 12-month rate</div>
                 <div class="margin-top--1">{{ DatePeriodFormat $Inflation.Date }}</div>
@@ -161,7 +161,7 @@
                     <a href="{{ $Inflation.FigureURIs.Data }}" class="tile__link margin-left--1">Data</a>
                 </div>
             </article>
-            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2 height-md--55">
+            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2 height-md--56">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">GDP</span></h2></header>
                 <div class="margin-top--2">Quarter on Quarter</div>
                 <div class="margin-top--1">{{ DatePeriodFormat $GDP.Date }}</div>
@@ -180,7 +180,7 @@
                 </div>
             </article>
             <article class="tile tile__content margin-top-md--6 margin-left-md--1 height-md--47">
-                <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--2 margin-left--0"><span class="tile__title">UK population</span></h2></header>
+                <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--5 margin-left--0"><span class="tile__title">UK population</span></h2></header>
                 <div class="margin-top--2">Mid-year estimate ({{ DatePeriodFormat $Population.Date }})</div>
                 <div class="tile__figure">{{ $Population.Figure }}</div>
                 <div class="margin-top--2">

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -98,7 +98,6 @@
                     <a href="{{ $Population.FigureURIs.Data }}" class="tile__link margin-left--1">Data</a>
                 </div>
             </article>
-            {{ template "homepage/promos" . }}
         </div>
     </div>
     <!--medium-->
@@ -142,12 +141,9 @@
                     </div>
                 </section>
             </article>
-            <div>
-            {{ template "homepage/promos" . }} 
-            </div>
         </div>
         <div class="col col--md-30">
-            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2 height-md--53">
+            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2 height-md--55">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Inflation</span></h2></header>
                 <div class="margin-top--2">CPIH 12-month rate</div>
                 <div class="margin-top--1">{{ DatePeriodFormat $Inflation.Date }}</div>
@@ -165,7 +161,7 @@
                     <a href="{{ $Inflation.FigureURIs.Data }}" class="tile__link margin-left--1">Data</a>
                 </div>
             </article>
-            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2 height-md--53">
+            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2 height-md--55">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">GDP</span></h2></header>
                 <div class="margin-top--2">Quarter on Quarter</div>
                 <div class="margin-top--1">{{ DatePeriodFormat $GDP.Date }}</div>
@@ -183,8 +179,8 @@
                     <a href="{{ $GDP.FigureURIs.Data }}" class="tile__link margin-left--1">Data</a>
                 </div>
             </article>
-            <article class="tile tile__content margin-top-md--6 margin-left-md--1">
-                <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">UK population</span></h2></header>
+            <article class="tile tile__content margin-top-md--6 margin-left-md--1 height-md--47">
+                <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--2 margin-left--0"><span class="tile__title">UK population</span></h2></header>
                 <div class="margin-top--2">Mid-year estimate ({{ DatePeriodFormat $Population.Date }})</div>
                 <div class="tile__figure">{{ $Population.Figure }}</div>
                 <div class="margin-top--2">
@@ -192,7 +188,6 @@
                     <a href="{{ $Population.FigureURIs.Data }}" class="tile__link margin-left--1">Data</a>
                 </div>
             </article>
-            {{ template "homepage/latest-releases" . }}
         </div>
     </div>
     <!--mobile-->
@@ -284,7 +279,6 @@
                     </div>
                 </div>
             </article>
-            {{ template "homepage/promos" . }}
         </div>
     </div>
     <button class="col btn btn--full-width btn--primary btn--focus tile__button hide--md hide--lg nojs--hide js-main-feature-compress-button"

--- a/assets/templates/homepage/promos.tmpl
+++ b/assets/templates/homepage/promos.tmpl
@@ -1,9 +1,9 @@
 <div class="wrapper padding-left--0 padding-right--0 background-gallery">
-    <div class="tiles col-wrap">
-        <div class="col col--md-22 margin-left-md--1 margin-left-lg--1 col--lg-29 background--white margin-bottom--0 margin-top--2">
+    <div class="tiles margin-top-sm--5 col-wrap">
+        <div class="col col--md-22 margin-left-md--1 margin-left-lg--1 col--lg-29 background--white margin-bottom--0 margin-top-sm--4 margin-top-md--3 margin-top-lg--3">
             {{ template "partials/banners/survey" . }}
         </div>
-        <div class="col col--md-23 col--lg-29 background--white margin-left-md--2 margin-left-lg--1 margin-bottom--0 margin-top--2">
+        <div class="col col--md-23 col--lg-29 background--white margin-left-md--2 margin-left-lg--1 margin-bottom--0 margin-top-sm--1 margin-top-md--3 margin-top-lg--3">
             {{ template "partials/banners/census" . }}
         </div>
     </div>

--- a/assets/templates/homepage/promos.tmpl
+++ b/assets/templates/homepage/promos.tmpl
@@ -1,7 +1,9 @@
 <div class="wrapper padding-left--0 padding-right--0 background-gallery">
     <div class="tiles col-wrap">
-        <div class="col col--md-17 col--lg-29 background--white margin-left-md--2 margin-left-lg--1 margin-bottom--0 margin-top--2">
+        <div class="col col--md-22 margin-left-md--1 margin-left-lg--1 col--lg-29 background--white margin-bottom--0 margin-top--2">
             {{ template "partials/banners/survey" . }}
+        </div>
+        <div class="col col--md-23 col--lg-29 background--white margin-left-md--2 margin-left-lg--1 margin-bottom--0 margin-top--2">
             {{ template "partials/banners/census" . }}
         </div>
     </div>

--- a/assets/templates/partials/banners/census.tmpl
+++ b/assets/templates/partials/banners/census.tmpl
@@ -1,8 +1,8 @@
 <a class="promo__container" href="/census">
     <section class="promo__background--plum-gradient box__content box__content--homepage height-sm--14 height-md--22 height-lg--14 padding-top-sm--2 padding-top-md--2 padding-top-lg--2 margin-bottom--2">
         <div class="promo__copy promo__body--column padding-left--1">
-            <img class="padding-top--1 width-md--13 padding-bottom-md--1" alt="Census 2021" src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape.svg">
-            <p class="padding-top-lg--1 padding-top-sm--1 padding-top-md--3 promo__description margin-top--0 margin-bottom--0 padding-right--1 underline-link">
+            <img class="padding-top--1 padding-bottom-md--1" alt="Census 2021" src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape.svg">
+            <p class="padding-top-lg--1 padding-top-sm--1 padding-top-md--6 promo__description margin-top--0 margin-bottom--0 padding-right--1 underline-link">
                 {{ localise "CensusBannerBody" .Language 1 }}
             </p>
         </div>

--- a/assets/templates/partials/banners/census.tmpl
+++ b/assets/templates/partials/banners/census.tmpl
@@ -1,8 +1,8 @@
 <a class="promo__container" href="/census">
-    <section class="promo__background--plum-gradient box__content box__content--homepage height-sm--18 height-md--25 height-lg--16 padding-top-sm--3 padding-top-md--2 padding-top-lg--2 margin-bottom--2">
+    <section class="promo__background--plum-gradient box__content box__content--homepage height-sm--14 height-md--22 height-lg--14 padding-top-sm--2 padding-top-md--2 padding-top-lg--2 margin-bottom--2">
         <div class="promo__copy promo__body--column padding-left--1">
             <img class="padding-top--1 width-md--13 padding-bottom-md--1" alt="Census 2021" src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape.svg">
-            <p class="padding-top--1 promo__description margin-top--0 margin-bottom--0 padding-right--1 padding-top--0 underline-link">
+            <p class="padding-top-lg--1 padding-top-sm--1 padding-top-md--3 promo__description margin-top--0 margin-bottom--0 padding-right--1 underline-link">
                 {{ localise "CensusBannerBody" .Language 1 }}
             </p>
         </div>

--- a/assets/templates/partials/banners/survey.tmpl
+++ b/assets/templates/partials/banners/survey.tmpl
@@ -3,8 +3,8 @@
         <div class="promo__body padding-right--1 padding-top-md--2">
             <img class="hide--md-only" src="https://cdn.ons.gov.uk/assets/images/icon-checkbox.svg">
             <div class="promo__copy">
-                <h2 class="promo__heading margin-top--0 padding-top--0 padding-bottom--0">{{ localise "SurveyTakingPart" .Language 1 }}</h2>
-                <p class="promo__description margin-top--0 margin-bottom--0 underline-link">{{ localise "SurveyFindOut" .Language 1 }}</p>
+                <h2 class="promo__heading margin-top--0 padding-top--0 padding-bottom-sm--0 padding-bottom-md--0 padding-bottom-lg--1">{{ localise "SurveyTakingPart" .Language 1 }}</h2>
+                <p class="promo__description margin-top--0 margin-bottom--0 padding-bottom--0 underline-link">{{ localise "SurveyFindOut" .Language 1 }}</p>
             </div>
         </div>
     </section>

--- a/config/config.go
+++ b/config/config.go
@@ -33,7 +33,6 @@ func Get() (*Config, error) {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
 		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/11720cc"
-
 	}
 	return cfg, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/c9680eb"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/11720cc"
 
 	}
 	return cfg, nil

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/ONSdigital/dp-frontend-models v1.5.5
+	github.com/ONSdigital/dp-frontend-models v1.5.6
 	github.com/ONSdigital/dp-healthcheck v1.0.2
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/ONSdigital/dp-frontend-models v1.5.4 h1:aJDHnFgivyr1KvtE95kaPNn/de/19
 github.com/ONSdigital/dp-frontend-models v1.5.4/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-frontend-models v1.5.5 h1:a15CXDPsCqmaIC4mxBzwa6WBIql+dZ1Aa6kq4jR9DJY=
 github.com/ONSdigital/dp-frontend-models v1.5.5/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
+github.com/ONSdigital/dp-frontend-models v1.5.6 h1:PczSyRVst45I8YFjgYVwUaq6UBdUmy/e0J1eKnQ6ViY=
+github.com/ONSdigital/dp-frontend-models v1.5.6/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e h1:H2KVzsFp5oTbqjPXDlTHOB/LvYy2I6Mc8eSTLrmZkXs=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.2 h1:N8SzpYzdixVgJS9NMzTBA2RZ2bi3Am1wE5F8ROEpTYw=


### PR DESCRIPTION
### What

This PR updates some copy for the new homepage, as well as the layout of it in order to match the updated designs for `lg` and `md` viewports.

**Large**
![image](https://user-images.githubusercontent.com/23668262/84113711-ff79be00-aa22-11ea-8579-34247726e8f8.png)

**Medium**
![image](https://user-images.githubusercontent.com/23668262/84113753-16b8ab80-aa23-11ea-8113-a90002042873.png)

![image](https://user-images.githubusercontent.com/23668262/84113810-2df79900-aa23-11ea-9358-e44404409806.png)


This PR also fixes the promos bug on `sm` viewports. Previously, the main figures' "Show more/less" logic would hide/show the promos as well. Now, the promo tiles are beneath the release calendar tile and are always visible

**Small - before**
![image](https://user-images.githubusercontent.com/23668262/84113963-73b46180-aa23-11ea-88eb-86e4008e1296.png)

**Small - after**
![image](https://user-images.githubusercontent.com/23668262/84113993-7d3dc980-aa23-11ea-8ac4-7dfcbd19845e.png)


### How to review

- Check that code/markup changes make sense
- You can view these changes by running this alongside Sixteens on branch `feature/updated-homepage-layout`


### Who can review

Anyone but me
