### PR TITLE
Fix/md promo alignment

### DIFF
--- a/assets/locales/active.cy.toml
+++ b/assets/locales/active.cy.toml
@@ -576,8 +576,8 @@ description = "Get the latest data and analysis on coronavirus (COVID-19) in the
 one = "Y data a’r dadansoddiad diweddaraf ar y coronafeirws."
 
 [CensusBannerBody]
-description = "Help paint a picture of the nation and how we live."
-one = "Help paint a picture of the nation and how we live."
+description = "Discover how our census statistics help paint a picture of the nation and how we live."
+one = "Discover how our census statistics help paint a picture of the nation and how we live."
 
 [InFocus]
 description = "In focus"

--- a/assets/locales/active.en.toml
+++ b/assets/locales/active.en.toml
@@ -551,8 +551,8 @@ description = "Get the latest data and analysis on coronavirus (COVID-19) in the
 one = "Get the latest data and analysis on coronavirus (COVID-19) in the UK."
 
 [CensusBannerBody]
-description = "Help paint a picture of the nation and how we live."
-one = "Help paint a picture of the nation and how we live."
+description = "Discover how our census statistics help paint a picture of the nation and how we live."
+one = "Discover how our census statistics help paint a picture of the nation and how we live."
 
 [InFocus]
 description = "In focus"

--- a/assets/templates/homepage/promos.tmpl
+++ b/assets/templates/homepage/promos.tmpl
@@ -1,9 +1,9 @@
 <div class="wrapper padding-left--0 padding-right--0 background-gallery">
     <div class="tiles margin-top-sm--5 col-wrap">
-        <div class="col col--md-22 margin-left-md--1 margin-left-lg--1 col--lg-29 background--white margin-bottom--0 margin-top-sm--4 margin-top-md--3 margin-top-lg--3">
+        <div class="col col--md-23 margin-left-md--1 margin-left-lg--1 col--lg-29 background--white margin-bottom--0 margin-top-sm--4 margin-top-md--3 margin-top-lg--3">
             {{ template "partials/banners/survey" . }}
         </div>
-        <div class="col col--md-23 col--lg-29 background--white margin-left-md--2 margin-left-lg--1 margin-bottom--0 margin-top-sm--1 margin-top-md--3 margin-top-lg--3">
+        <div class="col col--md-23 col--lg-29 background--white margin-left-md--1 margin-left-lg--1 margin-bottom--0 margin-top-sm--1 margin-top-md--3 margin-top-lg--3">
             {{ template "partials/banners/census" . }}
         </div>
     </div>

--- a/assets/templates/partials/banners/census.tmpl
+++ b/assets/templates/partials/banners/census.tmpl
@@ -1,8 +1,8 @@
 <a class="promo__container" href="/census">
-    <section class="promo__background--plum-gradient box__content box__content--homepage height-sm--14 height-md--22 height-lg--14 padding-top-sm--2 padding-top-md--2 padding-top-lg--2 margin-bottom--2">
+    <section class="promo__background--plum-gradient box__content box__content--homepage height-sm--18 height-md--22 height-lg--14 padding-top-sm--2 padding-top-md--2 padding-top-lg--2 margin-bottom--2">
         <div class="promo__copy promo__body--column padding-left--1">
             <img class="padding-top--1 padding-bottom-md--1" alt="Census 2021" src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape.svg">
-            <p class="padding-top-lg--1 padding-top-sm--1 padding-top-md--6 promo__description margin-top--0 margin-bottom--0 padding-right--1 underline-link">
+            <p class="padding-top-lg--0 padding-top-sm--2 padding-top-md--3 promo__description margin-top--0 margin-bottom--0 padding-right--1 underline-link">
                 {{ localise "CensusBannerBody" .Language 1 }}
             </p>
         </div>


### PR DESCRIPTION
### What

- Fixed Survey promo tile width in `md` viewport so that it now aligns with the 2nd of the In Focus boxes underneath it
- Reverted the Census promo text back to what it should be and tweaked padding accordingly

**Before**
![image](https://user-images.githubusercontent.com/23668262/84142167-3c0ddf80-aa4c-11ea-9ae1-53011a8d2c1d.png)

**After**
![image](https://user-images.githubusercontent.com/23668262/84142218-4e881900-aa4c-11ea-886d-8841e9b9b485.png)

### How to review

Ensure updated design aligns with what's required. I've tested in different browsers and phone viewport sizes and all looks fine - no harm doing a quick spot check from that respect too, though
Check that code changes makes sense

### Who can review

Anyone but me
