### PR TITLE
Change employment tile col size in md viewport

### DIFF
--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -15,7 +15,7 @@
     <div class="hide--sm hide--md-only">
         <article class="col col--lg-29 col--md-29 tile margin-right--1 height--53">
             <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment</span></h2></header>
-            <section class="col col--lg-12 col--md-12 margin-right--1">
+            <section class="col col--lg-12 margin-right--1">
                 <div class="margin-top--1 tile__subheading">Employment rate</div>
                 <div class="margin-top-md--2 margin-top-lg--1">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                 <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
@@ -33,7 +33,7 @@
                 </div>
             </section>
             <div class="col tile__split-bar print--hide hide--md hide--lg"></div>
-            <section class="col margin-left--1 col--lg-12 col--md-12">
+            <section class="col margin-left--1 col--lg-12">
                 <div class="margin-top--1 tile__subheading">Unemployment rate</div>
                 <div class="margin-top-md--2 margin-top-lg--1">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                 <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
@@ -105,7 +105,7 @@
         <div class="col col--md-18">
             <article class="tile tile--employment-figures-stacked margin-left--1">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment</span></h2></header>
-                <section class="col col--md-12">
+                <section class="col col--md-15">
                     <div class="margin-top--2 tile__subheading">Employment rate</div>
                     <div class="margin-top-md--2">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                     <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
@@ -123,7 +123,7 @@
                     </div>
                 </section>
                 <div class="col tile__split-bar print--hide width-md--14 margin-left-md--0 margin-top-md--3"></div>
-                <section class="col col--md-12">
+                <section class="col col--md-15">
                     <div class="margin-top--1 tile__subheading">Unemployment rate</div>
                     <div class="margin-top-md--2">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                     <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
@@ -143,7 +143,7 @@
             </article>
         </div>
         <div class="col col--md-30">
-            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2 height-md--56">
+            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2 height-md--52">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Inflation</span></h2></header>
                 <div class="margin-top--2">CPIH 12-month rate</div>
                 <div class="margin-top--1">{{ DatePeriodFormat $Inflation.Date }}</div>
@@ -161,7 +161,7 @@
                     <a href="{{ $Inflation.FigureURIs.Data }}" class="tile__link margin-left--1">Data</a>
                 </div>
             </article>
-            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2 height-md--56">
+            <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2 height-md--52">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">GDP</span></h2></header>
                 <div class="margin-top--2">Quarter on Quarter</div>
                 <div class="margin-top--1">{{ DatePeriodFormat $GDP.Date }}</div>
@@ -179,8 +179,8 @@
                     <a href="{{ $GDP.FigureURIs.Data }}" class="tile__link margin-left--1">Data</a>
                 </div>
             </article>
-            <article class="tile tile__content margin-top-md--6 margin-left-md--1 height-md--47">
-                <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--5 margin-left--0"><span class="tile__title">UK population</span></h2></header>
+            <article class="tile tile__content margin-top-md--6 margin-left-md--1 height-md--43">
+                <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--4 margin-left--0"><span class="tile__title">UK population</span></h2></header>
                 <div class="margin-top--2">Mid-year estimate ({{ DatePeriodFormat $Population.Date }})</div>
                 <div class="tile__figure">{{ $Population.Figure }}</div>
                 <div class="margin-top--2">

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/11720cc"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/60c47e5"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What

- Increased `md` viewport col size for the Employment figures from `md--12` to `md--15`. This ensures the text wraps a bit closer to the edges of the tile width and subsequently decreases the height of the stacked employment tiles. This in turn means the Population tile is a bit shorter, ultimately ensuring a bit less whitespace is present in that tile
- Removed unneeded `col-md--12` classes from the Employment tile in the `large` viewport markup
- Decreased heights of other main figures tiles to ensure that they still lined up flush with the relevant parts of the Employment tile

**Before**
![image](https://user-images.githubusercontent.com/23668262/84241038-d0cd1780-aaf6-11ea-859f-c0bd0689facc.png)

**After**
![image](https://user-images.githubusercontent.com/23668262/84241024-c9a60980-aaf6-11ea-9a93-f3170f5947d9.png)


### How to review

- Run this branch alongside `fix/employment-stacked-height` in Sixteens to see the changes locally
- Ensure code changes make sense
- This has been tested across browsers and viewport sizes, but no harm in doing a second check

### Who can review

Anyone but me
