### PR TITLE
Set fixed height for employment/unemployment data descriptions

### DIFF
--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -17,7 +17,7 @@
             <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment</span></h2></header>
             <section class="col col--lg-12 margin-right--1">
                 <div class="margin-top--1 tile__subheading">Employment rate</div>
-                <div class="margin-top-md--2 margin-top-lg--1">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
+                <div class="margin-top-md--2 margin-top-lg--1 height-lg--11">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                 <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
                 <p class="tile__trend">
                     <span class="tile__trend__icon">
@@ -35,7 +35,7 @@
             <div class="col tile__split-bar print--hide hide--md hide--lg"></div>
             <section class="col margin-left--1 col--lg-12">
                 <div class="margin-top--1 tile__subheading">Unemployment rate</div>
-                <div class="margin-top-md--2 margin-top-lg--1">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
+                <div class="margin-top-md--2 margin-top-lg--1 height-lg--11">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                 <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
                 <p class="tile__trend">
                     <span class="tile__trend__icon">


### PR DESCRIPTION
### What

This PR sets an explicit height for desktop view of the homepage employment figures descriptions. This is because of the change from displaying a monthly figure to the annual figure instead, which changed the number of lines between the two and caused a discrepancy in the alignment

Ties into this [homepage controller PR](https://github.com/ONSdigital/dp-frontend-homepage-controller/pull/31)

**Without setting a height to the text**
![image](https://user-images.githubusercontent.com/23668262/86333354-b0026880-bc43-11ea-8e8b-ea048d3d1001.png)

**With setting explicit height to the text**
![image](https://user-images.githubusercontent.com/23668262/86333244-8e08e600-bc43-11ea-8aa4-5ec295caa3f0.png)

### How to review

- Ensure that the change makes sense

### Who can review

Anyone
