### PR TITLE
Non descriptive image alt for official statistic image on dataset landing page

### DIFF
--- a/assets/templates/datasetLandingPage/static.tmpl
+++ b/assets/templates/datasetLandingPage/static.tmpl
@@ -80,7 +80,7 @@
             <div class="col col--md-12 col--lg-15 meta__item">
                 {{ if .DatasetLandingPage.IsNationalStatistic}}
                     <a href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/">
-                        <img class="meta__image" src="/img/national-statistics.png" alt="National Statistics logo">
+                        <img class="meta__image" src="/img/national-statistics.png" alt="This is an accredited national statistic. For information about types of official statistics click this link.">
                     </a>
                 {{ end }}
                 <dt class="meta__term">{{ localise "Contact" .Language 1  }}</dt>


### PR DESCRIPTION
### What
Changed the image alt text where the official statistic image is shown for the frontend-renderer this is just the dataset landing page.

### How to review
1. Visit a dataset landing page
1. The alt text of the image will be not very descriptive - "National Statistics logo"
1. Check out this branch
1. See that the alt text of the image will now be "This is an accredited national statistic. For information about types of official statistics click this link."

### Who can review
Anyone