### PR TITLE
Fix - Incorrect use of list on dataset landing page

### DIFF
--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -229,7 +229,7 @@
             <div class="tiles__content tiles__content--nav">
                <ul class="list--neutral">
                   {{ range .DatasetLandingPage.Publications }}
-                  <li><a class="font-size--14" href="{{ .URL }}">{{ .Title }}</a></li>
+                  <li><a href="{{ .URL }}">{{ .Title }}</a></li>
                   {{ end }}
                </ul>
             </div>
@@ -241,7 +241,7 @@
             <div class="tiles__content tiles__content--nav">
                <ul class="list--neutral">
                   {{ range .DatasetLandingPage.RelatedLinks }}
-                  <li><a class="font-size--14" href="{{ .URL }}">{{ .Title }}</a></li>
+                  <li><a href="{{ .URL }}">{{ .Title }}</a></li>
                   {{ end }}
                </ul>
             </div>
@@ -251,10 +251,10 @@
          <div class="tiles__item tiles__item--nav-type margin-left--0 margin-right--0">
             <h3 class="tiles__title-h3 tiles__title-h3--nav"><img class="meta__image" src="/img/national-statistics.png" alt="National Statistics logo"><div class="padding-top--1 padding-bottom--1">National Statistic</div></h3>
             <div class="tiles__content tiles__content--nav">
-               <ul class="list--neutral">
+               <p class="margin-bottom--0">
                   Certified by the UK Statistics Authority as compliant with the Code of Practice for Official Statistics.
-                  <a class="block underline-link font-size--14" href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/">Learn more</a>
-               </ul>
+                  <a class="block underline-link" href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/">Learn more</a>
+               </p>
             </div>
          </div>
          {{ end }}


### PR DESCRIPTION
### What
Stop using `li` on dataset landing page when not in a list.

### How to review
1. Load a data set landing page and see it looks as it does.
1. Loads this page.
1. See that the page is unchanged apart from the font sizes in the tiles on the right side being increased to 16 as per the contact per detailss

### Who can review
Anyone
