### PR TITLE
Update list html validity

### DIFF
--- a/assets/templates/dataset-filter/filter-overview.tmpl
+++ b/assets/templates/dataset-filter/filter-overview.tmpl
@@ -35,7 +35,7 @@
                                         <div class="font-size--16 height-sm--3 height-md--10 nowrap-sm vertical-align-middle margin-left-sm--4 list--ellipses-sm overflow--hidden">
                                         <div class="height-sm--3 max-height-md--9 vertical-align-middle__contents--md list--ellipses-md">
                                             <ul class="list list--pipe-seperated list--pipe-seperated-ellipses">
-                                                <li class="list--no-pipe">{{if eq $length 0}}Nothing added{{else}}{{$length}} added:{{end}}</li>
+                                                <li class="list--no-separator">{{if eq $length 0}}Nothing added{{else}}{{$length}} added:{{end}}</li>
                                                 {{range $i, $c := $categories}}
                                                     <li>{{$c}}</li>
                                                 {{end}}

--- a/assets/templates/dataset-filter/filter-overview.tmpl
+++ b/assets/templates/dataset-filter/filter-overview.tmpl
@@ -35,7 +35,7 @@
                                         <div class="font-size--16 height-sm--3 height-md--10 nowrap-sm vertical-align-middle margin-left-sm--4 list--ellipses-sm overflow--hidden">
                                         <div class="height-sm--3 max-height-md--9 vertical-align-middle__contents--md list--ellipses-md">
                                             <ul class="list list--pipe-seperated list--pipe-seperated-ellipses">
-                                                <span>{{if eq $length 0}}Nothing added{{else}}{{$length}} added:{{end}}</span>
+                                                <li class="list--no-pipe">{{if eq $length 0}}Nothing added{{else}}{{$length}} added:{{end}}</li>
                                                 {{range $i, $c := $categories}}
                                                     <li>{{$c}}</li>
                                                 {{end}}

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/b416024"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/ffb158d"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What

Updated the HTML in the `filter-overview` partial to be valid syntax by nesting an `li` underneath the `ul` instead of a `span`.

This change also lead to some of the styles changing too. As such, there is also a [PR in Sixteens](https://github.com/ONSdigital/sixteens/pull/204) which adds a utility class, `list--no-pipe`, which forcibly removes the `:after` content on any specific list item 

### How to review

- [Pull latest Sixteens change from this branch](https://github.com/ONSdigital/sixteens/pull/204)
- Go to a filter page options page (you will need the Filter journey running). 
- Check that there is no material difference to the UI, but that the HTML is now valid

![image](https://user-images.githubusercontent.com/23668262/88626684-eeecd800-d0a2-11ea-9f0f-e5b135238c21.png)

### Who can review

Anyone but me
