### PR TITLE
added Welsh translation for ONS logo alt text

### DIFF
--- a/assets/locales/active.cy.toml
+++ b/assets/locales/active.cy.toml
@@ -32,11 +32,7 @@ one = "Swyddfa Ystadegau Gwladol"
 
 [Home]
 description = "Homepage"
-one = "Hafen"
-
-[Homepage]
-description = "Homepage"
-one = "Hafen"
+one = "Hafan"
 
 [ONSLogoAlt]
 description = "Office for National Statistics Logo - Homepage"

--- a/assets/locales/active.cy.toml
+++ b/assets/locales/active.cy.toml
@@ -38,6 +38,10 @@ one = "Hafen"
 description = "Homepage"
 one = "Hafen"
 
+[ONSLogoAlt]
+description = "Office for National Statistics Logo - Homepage"
+one = "Logo Swyddfa Ystadegau Gwladol - Hafan"
+
 [SkipToContent]
 description = "Skip to main content"
 one = "Skip to main content"

--- a/assets/locales/active.en.toml
+++ b/assets/locales/active.en.toml
@@ -30,6 +30,10 @@ one = "Home"
 description = "Homepage"
 one = "Homepage"
 
+[ONSLogoAlt]
+description = "Office for National Statistics Logo - Homepage"
+one = "Office for National Statistics logo - Homepage"
+
 [SkipToContent]
 description = "Skip to main content"
 one = "Skip to main content"

--- a/assets/locales/active.en.toml
+++ b/assets/locales/active.en.toml
@@ -26,10 +26,6 @@ one = "Office for National Statistics"
 description = "Homepage"
 one = "Home"
 
-[Homepage]
-description = "Homepage"
-one = "Homepage"
-
 [ONSLogoAlt]
 description = "Office for National Statistics Logo - Homepage"
 one = "Office for National Statistics logo - Homepage"

--- a/assets/templates/partials/header.tmpl
+++ b/assets/templates/partials/header.tmpl
@@ -7,10 +7,10 @@
             <div class="col col--lg-one-third col--md-one-third">
                 <a id="logo-link" href="/">
                     {{`<!--[if lte IE 8]>` | safeHTML}}
-                        <img class="logo" src="https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png" alt="{{ localise "OfficeForNationalStatistics" .Language 1 }} - {{ localise "Homepage" .Language 1 }}">
+                        <img class="logo" src="https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png" alt="{{ localise "ONSLogoAlt" .Language 1 }}">
                     {{`<![endif]-->` | safeHTML}}
                     {{`<!--[if gte IE 9]><!-->` | safeHTML}}
-                        <img class="logo" src="https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.svg" alt="{{ localise "OfficeForNationalStatistics" .Language 1 }} - {{ localise "Homepage" .Language 1 }}">
+                        <img class="logo" src="https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.svg" alt="{{ localise "ONSLogoAlt" .Language 1 }}">
                     {{`<![endif]-->` | safeHTML}}
                 </a>
             </div>


### PR DESCRIPTION
### What

This PR adds Welsh translation for the text, "Office for National Statistics logo - Homepage" that is applied to the ONS logo `alt` in the header. As the sentence structure differed between English and Welsh translations, it felt sensible to include the whole sentence as a separate key in the localisation files

### How to review

Check that the alt text for the ONS logo in the header is correctly applied as per text in the localisation files on a page handled by the frontend renderer (e.g. the new homepage or a CMD journey page).

You can change the language locally by setting the cookie, `lang`, to either `en` or `cy`. Once the page is refreshed, the site should be in the language chosen

### Who can review

Anyone but me