### PR TITLE
Fix - Official statistics wording on dataset landing page

### DIFF
--- a/assets/templates/datasetLandingPage/static.tmpl
+++ b/assets/templates/datasetLandingPage/static.tmpl
@@ -80,7 +80,7 @@
             <div class="col col--md-12 col--lg-15 meta__item">
                 {{ if .DatasetLandingPage.IsNationalStatistic}}
                     <a href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/">
-                        <img class="meta__image" src="/img/national-statistics.png" alt="This is an accredited national statistic. For information about types of official statistics click this link.">
+                        <img class="meta__image" src="/img/national-statistics.png" alt="This is an accredited National Statistic. Click for information about types of official statistics.">
                     </a>
                 {{ end }}
                 <dt class="meta__term">{{ localise "Contact" .Language 1  }}</dt>


### PR DESCRIPTION
### What
Changed the official statistics image alt text so it is less than 99 characters which is the limit read by some screen readers.

### How to review
1. Visit a dataset landing page
1. The alt text of the image will be very long - "This is an accredited national statistic. For information about types of official statistics click this link."
1. Check out this branch
1. See that the alt text of the image will now be "This is an accredited National Statistic. Click for information about types of official statistics."

### Who can review
Anyone
