### PR TITLE
Fix - Accessible CMD filter errors

### DIFF
--- a/assets/templates/dataset-filter/filter-overview.tmpl
+++ b/assets/templates/dataset-filter/filter-overview.tmpl
@@ -50,7 +50,7 @@
                         <div class="{{if .Data.PreviewAndDownloadDisabled}}btn--no-click{{end}} padding-bottom--4 padding-left--2 padding-top--2">
                             <div class="filter-overview__error-container" id="error-container" aria-atomic="true" role="alert" aria-live="assertive"></div>
                             <form method="post" action="/filters/{{.FilterID}}/submit">
-                                <input id="preview-download" type="submit" value="Apply filters" class="btn btn--primary {{if .Data.PreviewAndDownloadDisabled}}btn--primary-disabled{{end}} btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--17" name="preview-and-download" />
+                                <input id="preview-download" type="submit" value="Apply filters" aria-label="Apply filters" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--17" name="preview-and-download" />
                             </form>
                         </div>
                     </div>

--- a/assets/templates/dataset-filter/filter-overview.tmpl
+++ b/assets/templates/dataset-filter/filter-overview.tmpl
@@ -47,7 +47,7 @@
                             </li>
                             {{ end }}
                         </ul>
-                        <div class="{{if .Data.PreviewAndDownloadDisabled}}btn--no-click{{end}} padding-bottom--4 padding-left--2 padding-top--2">
+                        <div class="padding-bottom--4 padding-left--2 padding-top--2">
                             <div class="filter-overview__error-container" id="error-container" aria-atomic="true" role="alert" aria-live="assertive"></div>
                             <form method="post" action="/filters/{{.FilterID}}/submit">
                                 <input id="preview-download" type="submit" value="Apply filters" aria-label="Apply filters" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--17" name="preview-and-download" />

--- a/assets/templates/dataset-filter/filter-overview.tmpl
+++ b/assets/templates/dataset-filter/filter-overview.tmpl
@@ -48,7 +48,7 @@
                             {{ end }}
                         </ul>
                         <div class="{{if .Data.PreviewAndDownloadDisabled}}btn--no-click{{end}} padding-bottom--4 padding-left--2 padding-top--2">
-                            <div class="filter-overview__error-container" id="error-container"></div>
+                            <div class="filter-overview__error-container" id="error-container" aria-atomic="true" role="alert" aria-live="assertive"></div>
                             <form method="post" action="/filters/{{.FilterID}}/submit">
                                 <input id="preview-download" type="submit" value="Apply filters" class="btn btn--primary {{if .Data.PreviewAndDownloadDisabled}}btn--primary-disabled{{end}} btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--17" name="preview-and-download" />
                             </form>


### PR DESCRIPTION
### What
The button for applying filters in CMD was visually disabled but clickable. When clicked it would show any errors that you had. After discussions with UX this visual disabling has been removed and the use of `role="alert"` and `aria-live="assertive"` on the error div means the errors are read by the screen reader. 

This visual disabling was done in JS as well so you will also need to checkout sixteens [fix/accessibility-disabled-but-clickable](https://github.com/ONSdigital/sixteens/tree/fix/accessibility-disabled-but-clickable)

Also, fix issue where button title was not being read by using `aria-label`.

### How to review
1. View the CMD filter page
1. See that the apply filter button is visually disabled but clickable
1. See that the errors are not announced to the screen reader when clicked.
1. Switch to this PR and the sixteens branch.
1. See that the button is no longer visually
1. See that the errors are announced as expected

### Who can review
Anyone but me
