### PR TITLE
Fix - Add quotes to the html language

### DIFF
--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang={{.Language}} xml:lang={{.Language}}>
+<html lang="{{.Language}}" xml:lang="{{.Language}}">
 <head>
 
     <title>{{ .Metadata.Title }} - {{ localise "OfficeForNationalStatistics" .Language 1 }}</title>


### PR DESCRIPTION
### What
Add quotes around html language attributes. This makes it much more tollerant when there is no language set.

### How to review
1. Load the new home page
1. See that the html attributes are not quoted
1. Switch to this branch
1. See that they are now quoted

### Who can review
Anyone but me
