### PR TITLE
Fix - Stop adding aria attributes to details elements

### DIFF
--- a/assets/templates/dataset-filter/age.tmpl
+++ b/assets/templates/dataset-filter/age.tmpl
@@ -7,8 +7,8 @@
                     <h1 class="page-intro__title font-weight-700">Age</h1>
                     {{if .Metadata.Description}}
                     <div class="font-size--16">
-                        <details role="group" class="margin-bottom--2 margin-bottom--2">
-                            <summary role="button">Learn more <span class="visuallyhidden"> about age</span></summary>
+                        <details class="margin-bottom--2 margin-bottom--2">
+                            <summary>Learn more <span class="visuallyhidden"> about age</span></summary>
                             <div class="panel" id="details-content-1">
                                 <p class="margin-top--0">
                                     {{.Metadata.Description}}

--- a/assets/templates/dataset-filter/geography.tmpl
+++ b/assets/templates/dataset-filter/geography.tmpl
@@ -9,8 +9,8 @@
 					</div>
 					{{if .Metadata.Description}}
 					<div class="font-size--16">
-						<details role="group" class="margin-bottom--2 margin-bottom--2">
-							<summary role="button">Learn more <span class="visuallyhidden"> about Geographic areas</span></summary>
+						<details class="margin-bottom--2 margin-bottom--2">
+							<summary>Learn more <span class="visuallyhidden"> about Geographic areas</span></summary>
 							<div class="panel" id="details-content-1">
 								<p class="margin-top--0">
 									{{.Metadata.Description}}

--- a/assets/templates/dataset-filter/hierarchy.tmpl
+++ b/assets/templates/dataset-filter/hierarchy.tmpl
@@ -7,8 +7,8 @@
                     <h1 class="page-intro__title font-weight-700">{{ .Data.DimensionName }}</h1>
                     {{if .Metadata.Description}}
                         <div class="font-size--16">
-                            <details role="group" class="margin-bottom--2 margin-bottom--2">
-                                <summary role="button">Learn more <span class="visuallyhidden"> about {{.Data.DimensionName}}</span></summary>
+                            <details class="margin-bottom--2 margin-bottom--2">
+                                <summary>Learn more <span class="visuallyhidden"> about {{.Data.DimensionName}}</span></summary>
                                 <div class="panel" id="details-content-1">
                                     <p class="margin-top--0">
                                         {{.Metadata.Description}}

--- a/assets/templates/dataset-filter/list-selector.tmpl
+++ b/assets/templates/dataset-filter/list-selector.tmpl
@@ -7,8 +7,8 @@
 					<h1 class="page-intro__title font-weight-700">{{.Data.Title}}</h1>
 					{{if .Metadata.Description}}
 						<div class="font-size--16">
-							<details role="group" class="margin-bottom--2 margin-bottom--2">
-								<summary role="button">Learn more <span class="visuallyhidden"> about {{.Data.Title}}</span></summary>
+							<details class="margin-bottom--2 margin-bottom--2">
+								<summary>Learn more <span class="visuallyhidden"> about {{.Data.Title}}</span></summary>
 								<div class="panel" id="details-content-1">
 									<p class="margin-top--0">
 										{{.Metadata.Description}}

--- a/assets/templates/dataset-filter/time.tmpl
+++ b/assets/templates/dataset-filter/time.tmpl
@@ -7,8 +7,8 @@
                     <h1 class="page-intro__title font-weight-700">Time</h1>
                     {{if .Metadata.Description}}
                     <div class="font-size--16">
-                        <details role="group" class="margin-bottom--2 margin-bottom--2">
-                            <summary role="button">Learn more <span class="visuallyhidden"> about time</span></summary>
+                        <details class="margin-bottom--2 margin-bottom--2">
+                            <summary>Learn more <span class="visuallyhidden"> about time</span></summary>
                             <div class="panel" id="details-content-1">
                                 <p class="margin-top--0">
                                     {{.Metadata.Description}}

--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -130,7 +130,7 @@
                      <span class="list-size">... (plus {{subtract $total_length 10}} more) </span>
                      {{end}}
                      {{if .Description}}
-                     <details role="group" class="margin-bottom--4 margin-top--1">
+                     <details class="margin-bottom--4 margin-top--1">
                         <summary><span class="summary">Learn more <span class="visuallyhidden">about {{.Title}}</span></span></summary>
                         <div class="panel">
                            <p class="margin-top--0">{{.Description}}</p>

--- a/assets/templates/datasetLandingPage/version-list.tmpl
+++ b/assets/templates/datasetLandingPage/version-list.tmpl
@@ -28,8 +28,8 @@
                      {{ end }}
                   </ul>
                   {{ if .Superseded }}
-                     <details role="group" class="margin-bottom--4">
-                        <summary role="button" aria-controls="details-content-0">
+                     <details class="margin-bottom--4">
+                        <summary>
                            <span class="summary underline-link ">Corrections</span>
                         </summary>
                         <div class="panel padding-top--1 padding-bottom--1 margin-bottom-2" id="details-content-0">

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/9c4c0bc"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/f7671b7"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What
The details do not need these additional aria attributes as they are well supported and polyfill adds the necessary attributes when needed (for IE11)

### How to review
1. Open a page with a `<details>` e.g. a CMD dataset filter with a description
1. See that the details expand and collapse but is confusing with a screen reader
1. Switch to this branch and `sixteens` `fix/accessibility-details-polyfill-not-needed`
1. See that details are more straight forward from a screen reader and still work 

### Who can review
Anyone but me
