### PR TITLE
add aria expanded attribute to the mobile menu toggles

### DIFF
--- a/assets/templates/partials/header.tmpl
+++ b/assets/templates/partials/header.tmpl
@@ -48,13 +48,13 @@
         <nav>
             <ul class="nav--controls">
                 <li class="nav--controls__item">
-                    <a href="#nav-primary" id="menu-toggle" aria-controls="nav-primary" class="nav--controls__menu {{if .SearchDisabled}} nav--controls__no-search{{end}}">
+                    <a href="#nav-primary" id="menu-toggle" aria-controls="nav-primary" aria-expanded="false" class="nav--controls__menu {{if .SearchDisabled}} nav--controls__no-search{{end}}">
                         <span class="nav--controls__text">{{ localise "Menu" .Language 1 }}</span>
                     </a>
                 </li>
                 {{if not .SearchDisabled}}
                 <li class="nav--controls__item ">
-                    <a href="#nav-search" id="search-toggle" aria-controls="nav-search" class="nav--controls__search">
+                    <a href="#nav-search" id="search-toggle" aria-controls="nav-search" aria-expanded="false" class="nav--controls__search">
                         <span class="nav--controls__text">{{ localise "Search" .Language 1 }}</span>
                     </a>
                 </li>

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/71a2d15"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/9c4c0bc"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What

Added the aria-expanded attribute to the menu and search toggles in the mobile nav.

### How to review

1 - Emulate/use a mobile device.
2 - Navigate to the homepage.
3 - Inspect the HTML for the Menu toggle
4 - There should be an aria-expanded=false attribute present.
5 - Inspect the HTML for the Search toggle
6 - There should be an aria-expanded=false attribute present.

(The functionality to toggle the value is included in a PR in the sixteens repo)

### Who can review
