### PR TITLE
Fix - Set correct page title for 404 pages

### DIFF
--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -2,7 +2,9 @@
 <html lang={{.Language}} xml:lang={{.Language}}>
 <head>
 
-    <title>{{ .Metadata.Title }} - {{ localise "OfficeForNationalStatistics" .Language 1 }}</title>
+    <title>{{ if .Metadata.Title -}}{{ .Metadata.Title }}
+      {{ else if .Error -}}{{if .Error.Title }}{{ .Error.Title }}{{- end }}
+      {{- end}} - {{ localise "OfficeForNationalStatistics" .Language 1 }}</title>
     <meta name="description" content="{{ .Metadata.Description}}">
     <meta name="keywords" content="{{range .Metadata.Keywords}} {{- .}}, {{end}}">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />


### PR DESCRIPTION
### What
When landing on a 404 page the page title contains just the standard ending but no specifics to the page. This resolves it by using the error title when it has one

### How to review
1. Go to a bad url e.g. http://localhost:20000/apfhoafhaohf
1. See that the page title is blank
1. Switch to this branch and restart
1. Refresh the page
1. See that title is now the error title followed by the standard ending

### Who can review
Anyone but me
