### PR TITLE
Fix - Covid banner contrast

### DIFF
--- a/assets/templates/partials/banners/covid.tmpl
+++ b/assets/templates/partials/banners/covid.tmpl
@@ -1,4 +1,4 @@
-<div class="background--pineapple-yellow wrapper banner__bottom-shadow margin-top--3 margin-bottom--3">
+<div class="background--pineapple-yellow wrapper banner__bottom-shadow margin-top--3 margin-bottom--3 js-hover-click">
     <div class="col-wrap">
         <a href="/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases">
             <div class="col">


### PR DESCRIPTION
### What
Change the link colour for the covid banner to increase contrast

### How to review
1. Load the new home page
1. See that the link in the banner does not stand out against the yellow background
1. Switch to this branch and sixteens branch `fix/covid-text-contrast`
1. See that it is now improved and using colour `#003c57`

### Who can review
Anyone but me
