### PR TITLE
Fix - Language of language switch link

### DIFF
--- a/assets/templates/partials/header.tmpl
+++ b/assets/templates/partials/header.tmpl
@@ -17,9 +17,9 @@
             <div class="col col--lg-two-thirds col--md-two-thirds hide--sm print--hide language--js__container">
                 <div class="language">
                     {{if eq .Language "cy"}}
-                        <a class="language__link icon--hide" href="{{ domainSetLang .SiteDomain .URI "en" }}">{{ localise "EnglishToggle" .Language 1 }}</a> | {{ localise "WelshToggle" .Language 1 }}
+                        <a class="language__link icon--hide" lang="en-GB" href="{{ domainSetLang .SiteDomain .URI "en" }}">{{ localise "EnglishToggle" .Language 1 }}</a> | {{ localise "WelshToggle" .Language 1 }}
                     {{ else }}
-                        {{ localise "EnglishToggle" .Language 1 }} | <a class="language__link icon--hide" href="{{ domainSetLang .SiteDomain .URI "cy" }}">{{ localise "WelshToggle" .Language 1 }}</a>
+                        {{ localise "EnglishToggle" .Language 1 }} | <a class="language__link icon--hide" lang="cy" href="{{ domainSetLang .SiteDomain .URI "cy" }}">{{ localise "WelshToggle" .Language 1 }}</a>
                     {{end}}
                 </div>
             </div>


### PR DESCRIPTION
### What
Set link to correct language so that it is read by screen reader correctly

### How to review
#### Option 1 - With NVDA on Windows in Chrome or Edge latest (not IE11)
1. Load any page rendered by this (e.g. home page, error page or CMD page)
1. Hear that `Cymraeg` is not read correctly (something like _sim-rig_)
1. Switch to this branch and hear it read correctly

#### Option 2 - Looking at the source
1. Load any page rendered by this (e.g. home page, error page or CMD page)
1. See that the link to `cy.ons.gov.uk` has no `lang` attribute
1. Switch to this branch and see that it has a `lang` attribute of `cy`

### Who can review
Anyone but me