### PR TITLE
Fix - Homepage - Image alt

### DIFF
--- a/assets/templates/homepage/around-the-ons.tmpl
+++ b/assets/templates/homepage/around-the-ons.tmpl
@@ -5,7 +5,7 @@
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
         <article tabindex="0" class="tile tile__highlighted-content">
             <div class="tile__highlighted-content-image-container">
-                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/local-statistics.png">
+                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/local-statistics.png" alt="Local statistics logo">
             </div>
             <h2 class="margin-bottom--0 margin-top--0">
                 <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/help/localstatistics">
@@ -18,7 +18,7 @@
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
         <article tabindex="0" class="tile tile__highlighted-content">
             <div class="tile__highlighted-content-image-container">
-                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/data-strategy.png">
+                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/data-strategy.png" alt="Data strategy logo">
             </div>
             <h2 class="margin-bottom--0 margin-top--0">
                 <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/aboutus/transparencyandgovernance/datastrategy">
@@ -31,7 +31,7 @@
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
         <article tabindex="0" class="tile tile__highlighted-content">
             <div class="tile__highlighted-content-image-container">
-                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/ons-centres.png">
+                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/ons-centres.png" alt="ONS centres logo">
             </div>
             <h2 class="margin-bottom--0 margin-top--0">
                 <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/aboutus/whatwedo/programmesandprojects/onscentres">
@@ -44,7 +44,7 @@
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
         <article tabindex="0" class="tile tile__highlighted-content">
             <div class="tile__highlighted-content-image-container">
-                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/other-govt-statistics.png">
+                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/other-govt-statistics.png" alt="GOV.UK logo">
             </div>
             <h2 class="margin-bottom--0 margin-top--0">
                 <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.gov.uk/government/statistics">

--- a/assets/templates/homepage/in-focus.tmpl
+++ b/assets/templates/homepage/in-focus.tmpl
@@ -6,7 +6,7 @@
         <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
             <article tabindex="0" class="tile tile__highlighted-content">
                 <div class="tile__highlighted-content-image-container">
-                    <img class="tile__highlighted-content-image" src="{{if .ImageURL }}{{.ImageURL}}{{else}}https://cdn.ons.gov.uk/assets/images/featured-content-default.svg{{end}}">
+                    <img class="tile__highlighted-content-image" src="{{if .ImageURL }}{{.ImageURL}}{{else}}https://cdn.ons.gov.uk/assets/images/featured-content-default.svg{{end}}" alt="{{.Title}} Logo">
                 </div>
                 <h2 class="margin-top--0 margin-bottom--0">
                     <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="{{ .URI }}">

--- a/assets/templates/partials/banners/survey.tmpl
+++ b/assets/templates/partials/banners/survey.tmpl
@@ -1,7 +1,7 @@
 <a class="promo__container" href="/surveys">
     <section class="promo__background--blue-gradient box__content box__content--homepage height-sm--14 height-md--22 height-lg--14 margin-bottom--2">
         <div class="promo__body padding-right--1 padding-top-md--2">
-            <img class="hide--md-only" src="https://cdn.ons.gov.uk/assets/images/icon-checkbox.svg">
+            <img class="hide--md-only" src="https://cdn.ons.gov.uk/assets/images/icon-checkbox.svg" alt="">
             <div class="promo__copy">
                 <h2 class="promo__heading margin-top--0 padding-top--0 padding-bottom-sm--0 padding-bottom-md--0 padding-bottom-lg--1">{{ localise "SurveyTakingPart" .Language 1 }}</h2>
                 <p class="promo__description margin-top--0 margin-bottom--0 padding-bottom--0 underline-link">{{ localise "SurveyFindOut" .Language 1 }}</p>


### PR DESCRIPTION
### What
Add alt text to the images on the home page

### How to review
1. Visit the new home page
1. See that the `Taking part in a survey` checkbox, `In focus` images and `Around the ONS` images have no `alt` text
1. Switch to this branch and restart the renderer
1. See that the images now have reasonable alt text.

### Who can review
Anyone but me