### PR TITLE
Fix - Remove duplicated nodes

### DIFF
--- a/assets/templates/partials/footer.tmpl
+++ b/assets/templates/partials/footer.tmpl
@@ -79,7 +79,4 @@
          </div>
       </div>
    </div>
-   <div id="viewport-sm" class="js-viewport-size"></div>
-   <div id="viewport-md" class="js-viewport-size"></div>
-   <div id="viewport-lg" class="js-viewport-size"></div>
 </footer>


### PR DESCRIPTION
### What
Remove DOM that is added by JS and then used by the JS.
https://github.com/ONSdigital/sixteens/blob/3e13124b9a9a2f0de4a41f995ecb44f9e1f72ee7/js/app/viewport-size.js#L2

### How to review
1. Load a page rendered by the renderer e.g. the home page
1. See that the `footer` has duplicated `div`s  with ids of `viewport-sm`, `viewport-md` and `viewport-lg`
1. Switch to this branch
1. See that the `footer` only has one of each `div`

### Who can review
Anyone but me
