### PR TITLE
Feature/homepage json ld

### DIFF
--- a/assets/templates/partials/json-ld/base.tmpl
+++ b/assets/templates/partials/json-ld/base.tmpl
@@ -18,5 +18,6 @@
         {{ if hasField $PageData "DatasetLandingPage" }}
             {{ template "partials/json-ld/dataset/common" . }}
         {{ end }}
+        {{ if eq $PageData.Page.Type "homepage" }}{{template "partials/json-ld/homepage" .}} {{ end }}
     }
 </script>

--- a/assets/templates/partials/json-ld/base.tmpl
+++ b/assets/templates/partials/json-ld/base.tmpl
@@ -5,6 +5,7 @@
         "name": {{ .Metadata.Title }},
         "publisher": {
         "@type": "GovernmentOrganization",
+        "name": "Office for National Statistics",  
         "logo": "https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png"
         },
         {{ if hasField $PageData "ContactDetails" }}

--- a/assets/templates/partials/json-ld/base.tmpl
+++ b/assets/templates/partials/json-ld/base.tmpl
@@ -5,7 +5,6 @@
         "name": {{ .Metadata.Title }},
         "publisher": {
         "@type": "GovernmentOrganization",
-        "name": "Office for National Statistics",  
         "logo": "https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png"
         },
         {{ if hasField $PageData "ContactDetails" }}

--- a/assets/templates/partials/json-ld/homepage.tmpl
+++ b/assets/templates/partials/json-ld/homepage.tmpl
@@ -1,3 +1,4 @@
+"name": "Office for National Statistics",
 "url":"https://www.ons.gov.uk/",
 "description":{{.Metadata.Description }},
     "sameAs":[

--- a/assets/templates/partials/json-ld/homepage.tmpl
+++ b/assets/templates/partials/json-ld/homepage.tmpl
@@ -1,4 +1,3 @@
-"name": "Office for National Statistics",
 "url":"https://www.ons.gov.uk/",
 "description":{{.Metadata.Description }},
     "sameAs":[

--- a/assets/templates/partials/json-ld/homepage.tmpl
+++ b/assets/templates/partials/json-ld/homepage.tmpl
@@ -1,0 +1,7 @@
+"url":"https://www.ons.gov.uk/",
+"description":{{.Metadata.Description }},
+    "sameAs":[
+        "https://twitter.com/ONS",
+        "https://www.facebook.com/ONS",
+        "https://www.linkedin.com/company/office-for-national-statistics/"
+    ]


### PR DESCRIPTION
### What

Added JSON LD to the homepage

### How to review

Check that the JSON LD script tag is implemented on the homepage when running `dp-frontend-homepage-controller` on branch `feature/homepage-jsonld`, and this renderer branch with the flag, `ENABLE_JSONLD_CONTROL` set to `true`

### Who can review

Anyone
