### PR TITLE
Add description logic for homepage

### DIFF
--- a/assets/locales/active.cy.toml
+++ b/assets/locales/active.cy.toml
@@ -34,6 +34,10 @@ one = "Swyddfa Ystadegau Gwladol"
 description = "Homepage"
 one = "Hafan"
 
+[HomepageDescription]
+description = "The UK's largest independent producer of official statistics and the recognised national statistical institute of the UK."
+one = "The UK's largest independent producer of official statistics and the recognised national statistical institute of the UK."
+
 [ONSLogoAlt]
 description = "Office for National Statistics Logo - Homepage"
 one = "Logo Swyddfa Ystadegau Gwladol - Hafan"

--- a/assets/locales/active.en.toml
+++ b/assets/locales/active.en.toml
@@ -26,6 +26,10 @@ one = "Office for National Statistics"
 description = "Homepage"
 one = "Home"
 
+[HomepageDescription]
+description = "The UK's largest independent producer of official statistics and the recognised national statistical institute of the UK."
+one = "The UK's largest independent producer of official statistics and the recognised national statistical institute of the UK."
+
 [ONSLogoAlt]
 description = "Office for National Statistics Logo - Homepage"
 one = "Office for National Statistics logo - Homepage"

--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -5,7 +5,7 @@
     <title>{{ if .Metadata.Title -}}{{ .Metadata.Title }}
       {{ else if .Error -}}{{if .Error.Title }}{{ .Error.Title }}{{- end }}
       {{- end}} - {{ localise "OfficeForNationalStatistics" .Language 1 }}</title>
-    <meta name="description" content="{{ .Metadata.Description}}">
+    {{if eq .Metadata.Title "Home"}}<meta name="description" content="{{ localise "HomepageDescription" .Language 1 }}">{{else}}<meta name="description" content="{{ .Metadata.Description}}">{{end}}
     <meta name="keywords" content="{{range .Metadata.Keywords}} {{- .}}, {{end}}">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta charset="utf-8"/>


### PR DESCRIPTION
### What

Add meta description for homepage in the renderer to ensure Welsh translation viability. This means there is now additional logic to determine whether or nor the page being served is the homepage or not

### How to review

Check code change makes sense and that the change is applied (i.e., a CMD dataset page's description still renders correctly and that the homepage description is rendered too)

### Who can review

Anyone but me
