### PR TITLE
Fix - Download as links

### DIFF
--- a/assets/templates/dataset-filter/preview-page.tmpl
+++ b/assets/templates/dataset-filter/preview-page.tmpl
@@ -1,3 +1,4 @@
+{{$datasetTitle := .DatasetTitle}}
 <div class="page-intro">
   <div class="wrapper">
       <div class="col-wrap">
@@ -85,6 +86,7 @@
                             href="{{.URI}}"
                             data-gtm-download-file="{{.URI}}"
                             data-gtm-download-type="{{.Extension}}"
+                            aria-label="Download {{$datasetTitle}} as {{.Extension}}"
                           >
                             <strong>Excel file</strong> <span class="font-size--14">({{ humanSize .Size }})</span>
                           </a>
@@ -118,6 +120,7 @@
                                     href="{{$download.URI}}"
                                     data-gtm-download-file="{{$download.URI}}"
                                     data-gtm-download-type="{{$download.Extension}}"
+                                    aria-label="Download {{$datasetTitle}} as {{$download.Extension}}"
                                   >
                                     <strong>{{$download.Extension}}</strong> ({{humanSize $download.Size}})
                                   </a>

--- a/assets/templates/datasetLandingPage/static.tmpl
+++ b/assets/templates/datasetLandingPage/static.tmpl
@@ -145,10 +145,8 @@
                                     class="btn btn--primary btn--thick"
                                     data-gtm-download-file="{{.URI}}"
                                     data-gtm-download-type="{{.Extension}}"
+                                    aria-label="{{ localise "DownloadInFormatWithSingleTitle" $Language 1  $.Metadata.Title .Extension  }}"
                                     >
-                                    <span class="visuallyhidden">{{ localise "DownloadInFormatWithSingleTitle" $Language 1  $.Metadata.Title .Extension  }}</span>
-
-                                    
                                     {{ if eq .Extension "csdb" }}
                                         {{ localise "StructuredText" $Language 1 }} ({{ humanSize .Size }})
                                     {{ else }}
@@ -185,8 +183,7 @@
                                     <div class="margin-bottom--2">
                                         {{ range .Downloads }}
                                             <div class="inline-block--md margin-bottom-sm--1">
-                                                <a href="/file?uri={{ $dataset.URI }}/{{ .URI }}" class="btn btn--primary btn--thick">
-                                                    <span class="visuallyhidden">{{ localise "DownloadInFormatWithFullTitle" $Language 1  $.Metadata.Title $dataset.Title .Extension }}</span>                                    
+                                                <a href="/file?uri={{ $dataset.URI }}/{{ .URI }}" class="btn btn--primary btn--thick" aria-label="{{ localise "DownloadInFormatWithFullTitle" $Language 1  $.Metadata.Title $dataset.Title .Extension }}">
                                                     {{ if eq .Extension "csdb" }}
                                                         {{ localise "StructuredText" $Language 1 }} ({{ humanSize .Size }})
                                                     {{ else }}

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/1e05dcd"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/e3ffca4"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What
Improve text read by screen readers for download as links

1. Dataset landing pages
1. CMD filter download pages

### How to review
1. Visit a page
1. Hear the screen reader read `.xls` etc
1. Switch to this branch and reload the page
1. Hear the screen reader read `Download {{title}} as {{format}}`


### Who can review
Anyone but me