### PR TITLE
change classes to match other download options button

### DIFF
--- a/assets/templates/dataset-filter/preview-page.tmpl
+++ b/assets/templates/dataset-filter/preview-page.tmpl
@@ -95,8 +95,8 @@
                     {{ end }}
                   </div>
                   <div id="other-downloads" class="{{if not .IsDownloadLoaded}}js-hidden{{end}} margin-top--2 js-show-hide show-hide show-hide--light show-hide--dark-bg border-top--iron-sm border-top--iron-md border-bottom--iron-sm border-bottom--iron-md col--lg-two-thirds col--md-two-thirds">
-                    <div class="js-show-hide__title show-hide__title show-hide__title--link-style margin-top--0 margin-bottom--0 padding-left--1 padding-right--0">
-                      <button class="js-show-hide__button js-show-hide__button--slim" type="button" aria-expanded="false" aria-controls="collapsible-0">
+                    <div class="js-show-hide__title show-hide__title show-hide__title--link-style margin-top--0 margin-bottom--0 padding-right--0">
+                      <button class="js-show-hide__button js-show-hide__button--slim btn--focus padding-left--1" type="button" aria-expanded="false" aria-controls="collapsible-0">
                         <h3 class="margin-top--0 underline-link font-size--17">Other download options</h3>
                       </button>
                     </div>


### PR DESCRIPTION
### What

Updated downloads options button on preview page to match dataset landing page, giving the button a correct focus state.

### How to review

- navigate to a filtered dataset preview page
- set focus to the 'Other Downloads Options' button
- the button should have an orange surround to indicate focus.

### Who can review

Anyone but me.
