### PR TITLE
Fix/homepage jsonld

### DIFF
--- a/assets/templates/partials/json-ld/base.tmpl
+++ b/assets/templates/partials/json-ld/base.tmpl
@@ -1,23 +1,26 @@
 {{$PageData := .}}
 <script type="application/ld+json">
+
     {
         "@context": "https://schema.org",
-        "name": {{ .Metadata.Title }},
-        "publisher": {
-        "@type": "GovernmentOrganization",
-        "name": "Office for National Statistics",  
-        "logo": "https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png"
-        },
-        {{ if hasField $PageData "ContactDetails" }}
-            "author": {
-            "@type": "Person",
-            "name": {{ .ContactDetails.Name }}
+        {{ if eq $PageData.Page.Type "homepage" }}{{template "partials/json-ld/homepage" .}}
+        {{else}}
+            "name": {{ .Metadata.Title }},
+            "publisher": {
+                "@type": "GovernmentOrganization",
+                "name": "Office for National Statistics",
+                "logo": "https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png"
             },
-        {{ end}}
-    "license": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
-        {{ if hasField $PageData "DatasetLandingPage" }}
-            {{ template "partials/json-ld/dataset/common" . }}
+            {{ if hasField $PageData "ContactDetails" }}
+                "author": {
+                    "@type": "Person",
+                    "name": {{ .ContactDetails.Name }}
+                },
+            {{ end}}
+            "license": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+            {{ if hasField $PageData "DatasetLandingPage" }}
+                {{ template "partials/json-ld/dataset/common" . }}
+            {{ end }}
         {{ end }}
-        {{ if eq $PageData.Page.Type "homepage" }}{{template "partials/json-ld/homepage" .}} {{ end }}
     }
 </script>

--- a/assets/templates/partials/json-ld/base.tmpl
+++ b/assets/templates/partials/json-ld/base.tmpl
@@ -2,24 +2,7 @@
 <script type="application/ld+json">
     {
         "@context": "https://schema.org",
-        {{ if eq $PageData.Page.Type "homepage" }}{{template "partials/json-ld/homepage" .}}
-        {{else}}
-            "name": {{ .Metadata.Title }},
-            "publisher": {
-                "@type": "GovernmentOrganization",
-                "name": "Office for National Statistics",
-                "logo": "https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png"
-            },
-            {{ if hasField $PageData "ContactDetails" }}
-                "author": {
-                    "@type": "Person",
-                    "name": {{ .ContactDetails.Name }}
-                },
-            {{ end}}
-            "license": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
-            {{ if hasField $PageData "DatasetLandingPage" }}
-                {{ template "partials/json-ld/dataset/common" . }}
-            {{ end }}
-        {{ end }}
+        {{ if eq $PageData.Page.Type "homepage" }}{{template "partials/json-ld/homepage" .}}{{end}}
+        {{ if hasField $PageData "DatasetLandingPage" }}{{ template "partials/json-ld/dataset/common" . }}{{ end }}
     }
 </script>

--- a/assets/templates/partials/json-ld/base.tmpl
+++ b/assets/templates/partials/json-ld/base.tmpl
@@ -1,6 +1,5 @@
 {{$PageData := .}}
 <script type="application/ld+json">
-
     {
         "@context": "https://schema.org",
         {{ if eq $PageData.Page.Type "homepage" }}{{template "partials/json-ld/homepage" .}}

--- a/assets/templates/partials/json-ld/dataset/common.tmpl
+++ b/assets/templates/partials/json-ld/dataset/common.tmpl
@@ -1,7 +1,7 @@
 {{$PageData := .}}
 "name": {{ .Metadata.Title }},
 "publisher": {
-    "@type": "GovernmentOrganization",
+    "@type": "Organization",
     "name": "Office for National Statistics",
     "logo": "https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png"
 },

--- a/assets/templates/partials/json-ld/dataset/common.tmpl
+++ b/assets/templates/partials/json-ld/dataset/common.tmpl
@@ -1,5 +1,20 @@
+{{$PageData := .}}
+"name": {{ .Metadata.Title }},
+"publisher": {
+    "@type": "GovernmentOrganization",
+    "name": "Office for National Statistics",
+    "logo": "https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png"
+},
+{{ if hasField $PageData "ContactDetails" }}
+"author": {
+    "@type": "Person",
+    "name": {{ .ContactDetails.Name }}
+},
+{{ end }}
+"license": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
 "@type": "Dataset",
-{{ if .DatasetLandingPage.IsTimeseries -}}{{ template "partials/json-ld/dataset/timeseries" . }}{{ end }}
+{{ if .DatasetLandingPage.IsTimeseries -}}{{ template "partials/json-ld/dataset/timeseries" . }}
+{{ end }}
 {{ if eq .Type "legacy_dataset_landing_page" }}
     {{ template "partials/json-ld/dataset/legacy" . }}
 {{else}}

--- a/assets/templates/partials/json-ld/homepage.tmpl
+++ b/assets/templates/partials/json-ld/homepage.tmpl
@@ -1,4 +1,7 @@
+"name": "Office for National Statistics",
+"@type": "GovernmentOrganization",
 "url":"https://www.ons.gov.uk/",
+"logo": "https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png",
 "description":{{ localise "HomepageDescription" .Language 1 }},
     "sameAs":[
         "https://twitter.com/ONS",


### PR DESCRIPTION
### What

Separate out the JSONLD that's specific to the homepage with the common JSONLD fields for the dataset

### How to review

Check that the code change makes sense

With `ENABLE_JSONLD_CONTROL=true` set on the renderer, go through the homepage and see that the JSONLD is there and matches requirements

A cursory look at the CMD dataset page and a legacy dataset page to see that the JSON LD still loads properly wouldn't go amiss (`/datasets/cpih01/editions/time-series/versions/1` and `economy/economicoutputandproductivity/output/datasets/indexofproduction`)

### Who can review

Anyone
