### PR TITLE
Remove alt text for homepage images

### DIFF
--- a/assets/templates/homepage/around-the-ons.tmpl
+++ b/assets/templates/homepage/around-the-ons.tmpl
@@ -5,7 +5,7 @@
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
         <article tabindex="0" class="tile tile__highlighted-content">
             <div class="tile__highlighted-content-image-container">
-                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/local-statistics.png" alt="Local statistics logo">
+                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/local-statistics.png" alt="">
             </div>
             <h2 class="margin-bottom--0 margin-top--0">
                 <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/help/localstatistics">
@@ -18,7 +18,7 @@
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
         <article tabindex="0" class="tile tile__highlighted-content">
             <div class="tile__highlighted-content-image-container">
-                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/data-strategy.png" alt="Data strategy logo">
+                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/data-strategy.png" alt="">
             </div>
             <h2 class="margin-bottom--0 margin-top--0">
                 <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/aboutus/transparencyandgovernance/datastrategy">
@@ -31,7 +31,7 @@
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
         <article tabindex="0" class="tile tile__highlighted-content">
             <div class="tile__highlighted-content-image-container">
-                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/ons-centres.png" alt="ONS centres logo">
+                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/ons-centres.png" alt="">
             </div>
             <h2 class="margin-bottom--0 margin-top--0">
                 <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/aboutus/whatwedo/programmesandprojects/onscentres">
@@ -44,7 +44,7 @@
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
         <article tabindex="0" class="tile tile__highlighted-content">
             <div class="tile__highlighted-content-image-container">
-                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/other-govt-statistics.png" alt="GOV.UK logo">
+                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/other-govt-statistics.png" alt="">
             </div>
             <h2 class="margin-bottom--0 margin-top--0">
                 <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.gov.uk/government/statistics">

--- a/assets/templates/homepage/in-focus.tmpl
+++ b/assets/templates/homepage/in-focus.tmpl
@@ -6,7 +6,7 @@
         <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
             <article tabindex="0" class="tile tile__highlighted-content">
                 <div class="tile__highlighted-content-image-container">
-                    <img class="tile__highlighted-content-image" src="{{if .ImageURL }}{{.ImageURL}}{{else}}https://cdn.ons.gov.uk/assets/images/featured-content-default.svg{{end}}" alt="{{.Title}} Logo">
+                    <img class="tile__highlighted-content-image" src="{{if .ImageURL }}{{.ImageURL}}{{else}}https://cdn.ons.gov.uk/assets/images/featured-content-default.svg{{end}}" alt="">
                 </div>
                 <h2 class="margin-top--0 margin-bottom--0">
                     <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="{{ .URI }}">


### PR DESCRIPTION
### What
The around ons image's alt text added no value and the in focus images will be set from florence later

### How to review
1. Load the home page and see that the `In focus` and `Around the ONS` images have alt text
1. Load this branch
1. See that the alt text is empty

### Who can review
Anyone but me
