### PR TITLE
Fix - Homepage semantic headings

### DIFF
--- a/assets/templates/homepage/around-the-ons.tmpl
+++ b/assets/templates/homepage/around-the-ons.tmpl
@@ -1,6 +1,6 @@
 <section>
     <div class="col">
-        <h2 class="margin-top--0 font-size--30">{{ localise "AroundTheONS" .Language 1 }}</h2>
+        <h1 class="margin-top--0 font-size--h2 font-size--30">{{ localise "AroundTheONS" .Language 1 }}</h2>
     </div>
     <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
         <article tabindex="0" class="tile tile__highlighted-content">

--- a/assets/templates/homepage/in-focus.tmpl
+++ b/assets/templates/homepage/in-focus.tmpl
@@ -1,6 +1,6 @@
 <section>
     <div class="col">
-        <h2 class="font-size--30 margin-top--1">{{ localise "InFocus" .Language 1 }}</h2>
+        <h1 class="font-size--h2 font-size--30 margin-top--1">{{ localise "InFocus" .Language 1 }}</h2>
     </div>
     {{ range .Data.Featured }}
         <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">

--- a/assets/templates/partials/banners/cookies.tmpl
+++ b/assets/templates/partials/banners/cookies.tmpl
@@ -1,32 +1,34 @@
-<form action="/cookies/accept-all" method="GET" id="global-cookie-message" class="cookies-banner cookies-banner--hidden js-cookies-banner-form clearfix"
-            aria-label="cookie banner">
-    <div class="cookies-banner__wrapper wrapper js-cookies-banner-inform">
-        <div>
-            <div class="cookies-banner__message adjust-font-size--18">
-                <h3 class="cookies-banner__heading">{{ localise "CookiesBannerHeading" .Language 1 }}</h3>
-                <p class="cookies-banner__body">{{ localise "CookiesBannerOverview" .Language 1 | safeHTML }}</p>
-                <p class="cookies-banner__body">{{ localise "CookiesBannerWhyWeUse" .Language 1 }}</p>
-            </div>
-            <div class="cookies-banner__buttons">
-                <div class="nojs--hide cookies-banner__button cookies-banner__button--accept">
-                    <button class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies" type="submit">{{ localise "CookiesBannerAcceptAllAction" .Language 1 }}</button>
-                </div>
-                <div class="cookies-banner__button">
-                    <a role="button" href="/cookies" class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies">{{ localise "CookiesBannerSetPreferencesAction" .Language 4 }}</a>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="hidden js-cookies-banner-confirmation" tabindex="-1">
-        <div class="cookies-banner__wrapper wrapper">
-            <div class="col">
+<section>
+    <form action="/cookies/accept-all" method="GET" id="global-cookie-message" class="cookies-banner cookies-banner--hidden js-cookies-banner-form clearfix"
+                aria-label="cookie banner">
+        <div class="cookies-banner__wrapper wrapper js-cookies-banner-inform">
+            <div>
                 <div class="cookies-banner__message adjust-font-size--18">
-                    <p class="cookies-banner__confirmation-message">
-                        {{ localise "CookiesBannerSuccess" .Language 1 | safeHTML }}
-                        <button type="button" class="cookies-banner__button--hide js-hide-cookies-banner">{{ localise "CookiesBannerHide" .Language 1 }}</button>
-                    </p>
+                    <h1 class="cookies-banner__heading font-size--h3">{{ localise "CookiesBannerHeading" .Language 1 }}</h1>
+                    <p class="cookies-banner__body">{{ localise "CookiesBannerOverview" .Language 1 | safeHTML }}</p>
+                    <p class="cookies-banner__body">{{ localise "CookiesBannerWhyWeUse" .Language 1 }}</p>
+                </div>
+                <div class="cookies-banner__buttons">
+                    <div class="nojs--hide cookies-banner__button cookies-banner__button--accept">
+                        <button class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies" type="submit">{{ localise "CookiesBannerAcceptAllAction" .Language 1 }}</button>
+                    </div>
+                    <div class="cookies-banner__button">
+                        <a role="button" href="/cookies" class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies">{{ localise "CookiesBannerSetPreferencesAction" .Language 4 }}</a>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
-</form>
+        <div class="hidden js-cookies-banner-confirmation" tabindex="-1">
+            <div class="cookies-banner__wrapper wrapper">
+                <div class="col">
+                    <div class="cookies-banner__message adjust-font-size--18">
+                        <p class="cookies-banner__confirmation-message">
+                            {{ localise "CookiesBannerSuccess" .Language 1 | safeHTML }}
+                            <button type="button" class="cookies-banner__button--hide js-hide-cookies-banner">{{ localise "CookiesBannerHide" .Language 1 }}</button>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+</section>

--- a/assets/templates/partials/banners/covid.tmpl
+++ b/assets/templates/partials/banners/covid.tmpl
@@ -1,13 +1,13 @@
-<div class="background--pineapple-yellow wrapper banner__bottom-shadow margin-top-sm--7 margin-top-md--5 margin-top-lg--3 margin-bottom--3 js-hover-click">
+<section class="background--pineapple-yellow wrapper banner__bottom-shadow margin-top-sm--7 margin-top-md--5 margin-top-lg--3 margin-bottom--3 js-hover-click">
     <div class="col-wrap">
         <a href="/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases">
             <div class="col">
-                <h2 class="banner__heading margin-top--1 font-weight-700 
-                        adjust-font-size--30">{{ localise "Covid19BannerTitle" .Language 1 }}</h2>
+                <h1 class="banner__heading margin-top--1 font-weight-700 
+                        font-size--h2 adjust-font-size--30">{{ localise "Covid19BannerTitle" .Language 1 }}</h2>
                 <p class="underline-link banner__link banner__body margin-top--0 margin-bottom--1">
                     {{ localise "Covid19BannerBody" .Language 1 }}
                 </p>
             </div>
         </a>
     </div>
-</div>
+</section>

--- a/assets/templates/partials/footer.tmpl
+++ b/assets/templates/partials/footer.tmpl
@@ -1,82 +1,84 @@
 <footer class="print--hide padding-top--13">
-    {{ if .ShowFeedbackForm }}
-        {{ template "partials/feedback" }}
-    {{ end }}
-   <h2 class="visuallyhidden">{{ localise "FooterLinks" .Language 1 }}</h2>
-   <div class="footer">
-      <div class="wrapper">
-         <nav>
-            <div class="footer-nav col-wrap">
-               <div class="col col--lg-one-third col--md-one-third">
-                  <h3 class="footer-nav__heading">{{ localise "Help" .Language 1 }}</h3>
-                  <ul class="footer-nav__list">
-                     <li class="footer-nav__item">
-                        <a href="/help/accessibility">{{ localise "Accessibility" .Language 1 }}</a>
-                     </li>
-                     {{ if .EnableCookiesControl }}
+   <section>
+      {{ if .ShowFeedbackForm }}
+         {{ template "partials/feedback" }}
+      {{ end }}
+      <h1 class="visuallyhidden">{{ localise "FooterLinks" .Language 1 }}</h2>
+      <div class="footer">
+         <div class="wrapper">
+            <nav>
+               <div class="footer-nav col-wrap">
+                  <div class="col col--lg-one-third col--md-one-third">
+                     <h2 class="footer-nav__heading">{{ localise "Help" .Language 1 }}</h3>
+                     <ul class="footer-nav__list">
                         <li class="footer-nav__item">
-                           <a href="/cookies">{{ localise "Cookies" .Language 4 }}</a>
+                           <a href="/help/accessibility">{{ localise "Accessibility" .Language 1 }}</a>
+                        </li>
+                        {{ if .EnableCookiesControl }}
+                           <li class="footer-nav__item">
+                              <a href="/cookies">{{ localise "Cookies" .Language 4 }}</a>
+                           </li>
+                           <li class="footer-nav__item">
+                              <a href="/help/privacynotice">{{ localise "Privacy" .Language 1 }}</a>
+                           </li>
+                        {{ else }}
+                           <li class="footer-nav__item">
+                              <a href="/help/cookiesandprivacy">{{ localise "CookiesPrivacy" .Language 1 }}</a>
+                           </li>
+                        {{ end }}
+                        <li class="footer-nav__item">
+                           <a href="/help/termsandconditions">{{ localise "TermsConditions" .Language 1 }}</a>
+                        </li>
+                     </ul>
+                  </div>
+                  <div class="col col--lg-one-third col--md-one-third">
+                     <h2 class="footer-nav__heading">{{ localise "AboutONS" .Language 1 }}</h3>
+                     <ul class="footer-nav__list">
+                        <li class="footer-nav__item">
+                           <a href="/aboutus/whatwedo">{{ localise "WhatWeDo" .Language 1 }}</a>
                         </li>
                         <li class="footer-nav__item">
-                           <a href="/help/privacynotice">{{ localise "Privacy" .Language 1 }}</a>
+                           <a href="/aboutus/careers">{{ localise "Careers" .Language 1 }}</a>
                         </li>
-                     {{ else }}
                         <li class="footer-nav__item">
-                           <a href="/help/cookiesandprivacy">{{ localise "CookiesPrivacy" .Language 1 }}</a>
+                           <a href="/aboutus/contactus">{{ localise "ContactUs" .Language 1 }}</a>
                         </li>
-                     {{ end }}
-                     <li class="footer-nav__item">
-                        <a href="/help/termsandconditions">{{ localise "TermsConditions" .Language 1 }}</a>
-                     </li>
-                  </ul>
+                        <li class="footer-nav__item">
+                           <a href="/news">{{ localise "News" .Language 1 }}</a>
+                        </li>
+                        <li class="footer-nav__item">
+                           <a href="/aboutus/transparencyandgovernance/freedomofinformationfoi">{{ localise "FreedomInformation" .Language 1 }}</a>
+                        </li>
+                     </ul>
+                  </div>
+                  <div class="col col--lg-one-third col--md-one-third">
+                     <h2 class="footer-nav__heading">{{ localise "ConnectWithUs" .Language 1 }}</h3>
+                     <ul class="footer-nav__list">
+                        <li class="footer-nav__item">
+                           <a href="https://twitter.com/ONS" class="icon--hide" target="_blank">{{ localise "Twitter" .Language 1 }}</a>
+                        </li>
+                        <li class="footer-nav__item">
+                           <a href="https://www.facebook.com/ONS" class="icon--hide" target="_blank">{{ localise "Facebook" .Language 1 }}</a>
+                        </li>
+                        <li class="footer-nav__item">
+                           <a href="https://www.linkedin.com/company/office-for-national-statistics" class="icon--hide" target="_blank">{{ localise "LinkedIn" .Language 1 }}</a>
+                        </li>
+                        <li class="footer-nav__item">
+                           <a href="https://public.govdelivery.com/accounts/UKONS/subscribers/new" class="icon--hide" target="_blank">{{ localise "EmailAlerts" .Language 1 }}</a>
+                        </li>
+                     </ul>
+                  </div>
                </div>
-               <div class="col col--lg-one-third col--md-one-third">
-                  <h3 class="footer-nav__heading">{{ localise "AboutONS" .Language 1 }}</h3>
-                  <ul class="footer-nav__list">
-                     <li class="footer-nav__item">
-                        <a href="/aboutus/whatwedo">{{ localise "WhatWeDo" .Language 1 }}</a>
-                     </li>
-                     <li class="footer-nav__item">
-                        <a href="/aboutus/careers">{{ localise "Careers" .Language 1 }}</a>
-                     </li>
-                     <li class="footer-nav__item">
-                        <a href="/aboutus/contactus">{{ localise "ContactUs" .Language 1 }}</a>
-                     </li>
-                     <li class="footer-nav__item">
-                        <a href="/news">{{ localise "News" .Language 1 }}</a>
-                     </li>
-                     <li class="footer-nav__item">
-                        <a href="/aboutus/transparencyandgovernance/freedomofinformationfoi">{{ localise "FreedomInformation" .Language 1 }}</a>
-                     </li>
-                  </ul>
-               </div>
-               <div class="col col--lg-one-third col--md-one-third">
-                  <h3 class="footer-nav__heading">{{ localise "ConnectWithUs" .Language 1 }}</h3>
-                  <ul class="footer-nav__list">
-                     <li class="footer-nav__item">
-                        <a href="https://twitter.com/ONS" class="icon--hide" target="_blank">{{ localise "Twitter" .Language 1 }}</a>
-                     </li>
-                     <li class="footer-nav__item">
-                        <a href="https://www.facebook.com/ONS" class="icon--hide" target="_blank">{{ localise "Facebook" .Language 1 }}</a>
-                     </li>
-                     <li class="footer-nav__item">
-                        <a href="https://www.linkedin.com/company/office-for-national-statistics" class="icon--hide" target="_blank">{{ localise "LinkedIn" .Language 1 }}</a>
-                     </li>
-                     <li class="footer-nav__item">
-                        <a href="https://public.govdelivery.com/accounts/UKONS/subscribers/new" class="icon--hide" target="_blank">{{ localise "EmailAlerts" .Language 1 }}</a>
-                     </li>
-                  </ul>
-               </div>
+            </nav>
+         </div>
+         <div class="wrapper">
+            <div class="footer-license">
+               <img class="footer-license__img" alt="OGL" width="60" src="https://cdn.ons.gov.uk/assets/images/logo-ogl-footer.svg">
+               <p class="footer-license__text margin-left-sm--0">
+                  {{ localise "OGLFull" .Language 1 | safeHTML }}
+               </p>
             </div>
-         </nav>
-      </div>
-      <div class="wrapper">
-         <div class="footer-license">
-            <img class="footer-license__img" alt="OGL" width="60" src="https://cdn.ons.gov.uk/assets/images/logo-ogl-footer.svg">
-            <p class="footer-license__text margin-left-sm--0">
-               {{ localise "OGLFull" .Language 1 | safeHTML }}
-            </p>
          </div>
       </div>
-   </div>
+   </section>
 </footer>


### PR DESCRIPTION
### What
Add sections around different areas of homepage so we can have multiple semantically correct h1 headings
1. Cookie banner
1. Covid banner
1. In focus
1. Around the ONS
1. Footer

### How to review
1. Load the home page
1. See that the above areas have no h1
1. Switch to this branch
1. See the design is unchanged but are now using h1

### Who can review
Anyone but me
