### PR TITLE
Fix - Additional context for screen readers with browse button

### DIFF
--- a/assets/templates/dataset-filter/hierarchy.tmpl
+++ b/assets/templates/dataset-filter/hierarchy.tmpl
@@ -96,7 +96,7 @@
                                             </div>
                                             {{ if ne .SubNum "0" }}
                                                 <div class="view-link width-md--10 float-el--right-md text-right--md padding-top--1 height-sm--5 height-md--5">
-                                                    <input name="{{ .SubURL }}" id="{{.ID}}-children" type="submit" class="padding-top--0 text-align-top btn btn--link underline-link" value="Browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}"/>
+                                                    <input name="{{ .SubURL }}" id="{{.ID}}-children" type="submit" class="padding-top--0 text-align-top btn btn--link underline-link" aria-label="{{ .Label }}: browse {{.SubNum}} {{$.Type}}" value="Browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}"/>
                                                     <div class="inline-block view-link--icon">
                                                         <span class="icon icon-arrow-right--dark-small"></span>
                                                     </div>

--- a/assets/templates/dataset-filter/hierarchy.tmpl
+++ b/assets/templates/dataset-filter/hierarchy.tmpl
@@ -96,7 +96,7 @@
                                             </div>
                                             {{ if ne .SubNum "0" }}
                                                 <div class="view-link width-md--10 float-el--right-md text-right--md padding-top--1 height-sm--5 height-md--5">
-                                                    <input name="{{ .SubURL }}" id="{{.ID}}-children" type="submit" class="padding-top--0 text-align-top btn btn--link underline-link" aria-label="{{ .Label }}: browse {{.SubNum}} {{$.Type}}" value="Browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}"/>
+                                                    <input name="{{ .SubURL }}" id="{{.ID}}-children" type="submit" class="padding-top--0 text-align-top btn btn--link underline-link" aria-label="{{ .Label }}: browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}" value="Browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}"/>
                                                     <div class="inline-block view-link--icon">
                                                         <span class="icon icon-arrow-right--dark-small"></span>
                                                     </div>


### PR DESCRIPTION
### What

Added an `aria-label` attribute so that the dimension name (`Label`) to proffer additional context for screen reader users.

Where screen readers would initially read, e.g., "browse 5 areas", it will now read: "Wales: browse 5 areas".

### How to review

Pull branch and go to a filter dataset page. While the ticket specifically mentioned geography, this issue is something that was happening across the board. You could then test this change on a dataset with any dimensions that let you browse additional things (CPIH => Aggregate, for instance)

Ensure additional context read out by screen reader is clear

### Who can review

Anyone
