### PR TITLE
Fix - Announce when items added and removed from filters

### DIFF
--- a/assets/templates/partials/filter-selection.tmpl
+++ b/assets/templates/partials/filter-selection.tmpl
@@ -1,7 +1,7 @@
 <div class="filter-selection">
   <header>
     <div class="filter-selection__header">
-      <h2 class="font-weight-700" aria-live="assertive"><span class="font-size--21">{{$filterCount := len .Data.FiltersAdded}}{{ $filterCount }}</span> item{{if ne $filterCount 1 }}s{{end}} added</h2>
+      <h2 class="font-weight-700" aria-live="assertive"><span class="font-size--21">{{$filterCount := len .Data.FiltersAdded}}{{ $filterCount }}</span> item{{if ne $filterCount 1 }}s{{end}} selected</h2>
       {{ $val := len .Data.FiltersAdded }}
       {{ if gt $val 1 }}
       <a class="remove-all js-filter" href="{{ .Data.RemoveAll.URL }}">Remove all</a>

--- a/assets/templates/partials/filter-selection.tmpl
+++ b/assets/templates/partials/filter-selection.tmpl
@@ -1,7 +1,7 @@
 <div class="filter-selection">
   <header>
     <div class="filter-selection__header">
-      <h2 class="font-weight-700"><span class="font-size--21">{{ len .Data.FiltersAdded }}</span> item{{if ne (len .Data.FiltersAdded) 1 }}s{{end}} added</h2>
+      <h2 class="font-weight-700" aria-live="assertive"><span class="font-size--21">{{$filterCount := len .Data.FiltersAdded}}{{ $filterCount }}</span> item{{if ne $filterCount 1 }}s{{end}} added</h2>
       {{ $val := len .Data.FiltersAdded }}
       {{ if gt $val 1 }}
       <a class="remove-all js-filter" href="{{ .Data.RemoveAll.URL }}">Remove all</a>


### PR DESCRIPTION
### What
Announce to screen readers that there has been a change 

This has been tested with VoiceOver for Mac and NVDA. This component does not exist on mobile so no need to worry about VoiceOver for iPhone.

### How to review
1. Visit a CMD filter page
1. Add a filter with a screen reader enabled
1. Hear the filter is not announced
1. Switch to this branch
1. Add the filter and hear that it announces the number of filters

### Who can review
Anyone but me
