### PR TITLE
remove aria-hidden from the excel file tag

### DIFF
--- a/assets/templates/dataset-filter/preview-page.tmpl
+++ b/assets/templates/dataset-filter/preview-page.tmpl
@@ -72,7 +72,7 @@
                  </div>
                  {{end}}
                   <div class="loader-svg js-hidden">{{ template "partials/spinner" }}</div>
-                  <div id="excel-file" aria-hidden="true">
+                  <div id="excel-file">
                     {{ range .Data.Downloads }}
                       {{ if eq .Extension "xls" }}
                         {{ if .Skipped }}

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/9ba0d8d"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/37393eb"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What

Removed the default aria-hidden from the excel-file element, instead it will be dynamically set by JS if required (update in sixteens PR https://github.com/ONSdigital/sixteens/pull/217)

Needs the references to sixteens updating once that PR has been merged.

### How to review

- Apply filters to a dataset to create a custom download.
- Land on the download preview page with the file already available for download, the HTML element id='excel-file' should not have the attribute aria-hidden set

### Who can review

Anyone but me
