### PR TITLE
Fix - Missing file size from aria-label

### DIFF
--- a/assets/templates/dataset-filter/preview-page.tmpl
+++ b/assets/templates/dataset-filter/preview-page.tmpl
@@ -88,7 +88,9 @@
                             data-gtm-download-type="{{.Extension}}"
                             aria-label="Download {{$datasetTitle}} as {{.Extension}} ({{ humanSize .Size }})"
                           >
-                            <strong>Excel file</strong> <span class="font-size--14">({{ humanSize .Size }})</span>
+                            <span role="text">
+                              <strong>Excel file</strong> <span class="font-size--14">({{ humanSize .Size }})</span>
+                            </span>
                           </a>
                         {{ end }}
                       {{ end }}
@@ -122,7 +124,9 @@
                                     data-gtm-download-type="{{$download.Extension}}"
                                     aria-label="Download {{$datasetTitle}} as {{$download.Extension}} ({{humanSize $download.Size}})"
                                   >
-                                    <strong>{{$download.Extension}}</strong> ({{humanSize $download.Size}})
+                                    <span role="text">
+                                      <strong>{{$download.Extension}}</strong> ({{humanSize $download.Size}})
+                                    </span>
                                   </a>
                                 </div>
                               </li>

--- a/assets/templates/dataset-filter/preview-page.tmpl
+++ b/assets/templates/dataset-filter/preview-page.tmpl
@@ -86,7 +86,7 @@
                             href="{{.URI}}"
                             data-gtm-download-file="{{.URI}}"
                             data-gtm-download-type="{{.Extension}}"
-                            aria-label="Download {{$datasetTitle}} as {{.Extension}}"
+                            aria-label="Download {{$datasetTitle}} as {{.Extension}} ({{ humanSize .Size }})"
                           >
                             <strong>Excel file</strong> <span class="font-size--14">({{ humanSize .Size }})</span>
                           </a>
@@ -120,7 +120,7 @@
                                     href="{{$download.URI}}"
                                     data-gtm-download-file="{{$download.URI}}"
                                     data-gtm-download-type="{{$download.Extension}}"
-                                    aria-label="Download {{$datasetTitle}} as {{$download.Extension}}"
+                                    aria-label="Download {{$datasetTitle}} as {{$download.Extension}} ({{humanSize $download.Size}})"
                                   >
                                     <strong>{{$download.Extension}}</strong> ({{humanSize $download.Size}})
                                   </a>

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/742609d"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/5de212d"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What
Fix the server side rendered aria-label on the CMD download page

### How to review
1. Get to the CMD download page and wait for the download buttons to appear.
1. Refresh the page
1. See that the download buttons are missing the file size from their `aria-label`.
1. See that the download button contents is not read correctly on VO for iPhone
1. Switch to this branch 
1. See that the above issues are resolved

### Who can review
Anyone but me
