### PR TITLE
add templates for search page

### DIFF
--- a/assets/templates/search.tmpl
+++ b/assets/templates/search.tmpl
@@ -1,3 +1,6 @@
 <div class="search search--results-page print--hide" id="searchBar">
     {{ template "search/bar" . }}
 </div>
+<main id="main" role="main" tabindex="-1">
+    {{ template "search/results" . }}
+</main>

--- a/assets/templates/search.tmpl
+++ b/assets/templates/search.tmpl
@@ -1,0 +1,3 @@
+<div class="search search--results-page print--hide" id="searchBar">
+    {{ template "search/bar" . }}
+</div>

--- a/assets/templates/search/bar.tmpl
+++ b/assets/templates/search/bar.tmpl
@@ -2,7 +2,7 @@
     <form class="col-wrap search__form" action="/search">
         <h1>Search our website</h1>
         <label class="font-size--16 block" for="nav-search">Keyword(s) or time series ID</label>
-        <input type="search" autocomplete="off" class="search__input search__input--results-page col col--md-29 col--lg-29" id="nav-search" name="q" value="">
+        <input type="search" autocomplete="off" class="search__input search__input--results-page col col--md-29 col--lg-29" id="nav-search" name="q" value={{ .Data.Query}}>
         <button type="submit" class="search__button search__button--results-page col--md-3 col--lg-3" id="nav-search-submit">
             <span class="visuallyhidden">Search</span>
             <span class="icon icon-search--light"></span>

--- a/assets/templates/search/bar.tmpl
+++ b/assets/templates/search/bar.tmpl
@@ -1,0 +1,8 @@
+<div class="wrapper">
+    <form class="col-wrap search__form" action="/search">
+        <h1>Search our website</h1>
+        <label class="font-size--16 block" for="nav-search">Keyword(s) or time series ID</label>
+        <input type="search" autocomplete="off" class="search__input search__input--results-page col col--md-29 col--lg-29" id="nav-search" name="q" value="">
+        <button type="submit" class="search__button search__button--results-page col--md-3 col--lg-3" id="nav-search-submit"></button>
+    </form>
+</div>

--- a/assets/templates/search/bar.tmpl
+++ b/assets/templates/search/bar.tmpl
@@ -3,6 +3,9 @@
         <h1>Search our website</h1>
         <label class="font-size--16 block" for="nav-search">Keyword(s) or time series ID</label>
         <input type="search" autocomplete="off" class="search__input search__input--results-page col col--md-29 col--lg-29" id="nav-search" name="q" value="">
-        <button type="submit" class="search__button search__button--results-page col--md-3 col--lg-3" id="nav-search-submit"></button>
+        <button type="submit" class="search__button search__button--results-page col--md-3 col--lg-3" id="nav-search-submit">
+            <span class="visuallyhidden">Search</span>
+            <span class="icon icon-search--light"></span>
+        </button>
     </form>
 </div>

--- a/assets/templates/search/results.tmpl
+++ b/assets/templates/search/results.tmpl
@@ -1,0 +1,31 @@
+<div class="page-content border">
+    <div class="wrapper">
+        <h1>Search Results</h1>
+        <ul class="list--neutral flush">
+            {{ range .Data.Response.Items }}
+                <li class="col col--md-34 col--lg-40 search-results__item">
+                    <h3 class="search-results__title">
+                        <a href="{{ .URI}}">{{ .Description.Title}}</a>
+                    </h3>
+                    <p class="search-results__meta">
+                        {{ .Type}}
+                        |
+                        Released on {{dateFormat .Description.ReleaseDate}}
+                    </p>
+                    <div class="search-results__summary">
+                        {{ .Description.Summary}}
+                    </div>
+                    {{ if .Description.Keywords }}
+                        {{ $numberOfKeywords := len .Description.Keywords }}
+                        <p class="search-results__keywords">
+                            Keywords: 
+                            {{ range $i, $el := .Description.Keywords }}
+                                {{$el}}{{ if notLastItem $numberOfKeywords $i }},{{end}}
+                            {{end}}
+                        </p>
+                    {{end}}
+                </li>
+            {{end}}
+        </ul>
+    </div>
+</div>


### PR DESCRIPTION
### What

**Describe what you have changed and why.**
- Add search bar which contains an input box to enter a query and submit button
- Add search results container to list search responses based on the query

### How to review

**Describe the steps required to test the changes.**
- Check if the code makes sense
- Can test locally by running web instances, `dp-search-query`, `dp-frontend-search-controller` and then on the browser, go to `http://localhost:20000/search`
- Search for `housing` for example and the search results will be updated

Please note that updates to `dp-frontend-search-controller` is still in PR (https://github.com/ONSdigital/dp-frontend-search-controller/pull/2), therefore you may need to pull my commits locally and test from there. This PR description box will be updated once it has been merged into any environments.

Also, updates to the `dp-frontend-router` for the search is still in PR (https://github.com/ONSdigital/dp-frontend-router/pull/232) as well, therefore, you may need to pull my commits locally and test from there. This PR description box will be updated accordingly for this as well. **ALSO, you need to change the feature flag `NewSearchEnabled` in the router to `true`**

### Who can review

**Describe who worked on the changes, so that other people can review.**
Anyone - Justin made the changes