### PR TITLE
add slightly hacky patch to make the menu easier to  navigate on mobiles

### DIFF
--- a/assets/locales/active.cy.toml
+++ b/assets/locales/active.cy.toml
@@ -78,6 +78,10 @@ one = "Blog"
 description = "Menu"
 one = "Dewislen"
 
+[SubMenu]
+description = "sub menu"
+one = ""
+
 [Search]
 description = "Search"
 one = "Chwilio"

--- a/assets/locales/active.cy.toml
+++ b/assets/locales/active.cy.toml
@@ -80,7 +80,7 @@ one = "Dewislen"
 
 [SubMenu]
 description = "sub menu"
-one = ""
+one = "is-dewislen"
 
 [Search]
 description = "Search"

--- a/assets/locales/active.en.toml
+++ b/assets/locales/active.en.toml
@@ -70,6 +70,10 @@ one = "Blog"
 description = "Menu"
 one = "Menu"
 
+[SubMenu]
+description = "sub menu"
+one = "sub menu"
+
 [Search]
 description = "Search"
 one = "Search"

--- a/assets/templates/partials/header.tmpl
+++ b/assets/templates/partials/header.tmpl
@@ -66,9 +66,9 @@
                       <a class="primary-nav__link col col--md-7 col--lg-9" href="/">{{ localise "Home" .Language 1 }}</a>
                     </li>
                     <li class="primary-nav__item js-nav js-expandable ">
-						<a class="primary-nav__link col col--md-8 col--lg-10" href="/businessindustryandtrade" aria-expanded="false" aria-label="{{ localise "BusinessIndustryTrade" .Language 1 }} sub menu toggle">
+						<a class="primary-nav__link col col--md-8 col--lg-10" href="/businessindustryandtrade" aria-expanded="false" aria-label="{{ localise "BusinessIndustryTrade" .Language 1 }} {{ localise "SubMenu" .Language 1 }}">
 						    <span aria-hidden="true" class="expansion-indicator"></span>
-						    <span aria-label="{{ localise "BusinessIndustryTrade" .Language 1 }} sub menu toggle" role="text" class="submenu-title">
+						    <span aria-label="{{ localise "BusinessIndustryTrade" .Language 1 }} {{ localise "SubMenu" .Language 1 }}" role="text" class="submenu-title">
 						        {{ localise "BusinessIndustryTrade" .Language 1 }}
                             </span>
                         </a>
@@ -100,9 +100,9 @@
 						</ul>
 					</li>
 					<li class="primary-nav__item js-nav js-expandable ">
-						<a class="primary-nav__link col col--md-8 col--lg-10" href="/economy" aria-expanded="false" aria-label="{{ localise "Economy" .Language 1 }} sub menu toggle">
+						<a class="primary-nav__link col col--md-8 col--lg-10" href="/economy" aria-expanded="false" aria-label="{{ localise "Economy" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle">
 						    <span aria-hidden="true" class="expansion-indicator"></span>
-						    <span aria-label="{{ localise "Economy" .Language 1 }} sub menu toggle" role="text" class="submenu-title">
+						    <span aria-label="{{ localise "Economy" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle" role="text" class="submenu-title">
 						        {{ localise "Economy" .Language 1 }}
 						    </span>
 						</a>
@@ -137,9 +137,9 @@
 						</ul>
 					</li>
 					<li class="primary-nav__item js-nav js-expandable ">
-						<a class="primary-nav__link col col--md-8 col--lg-10" href="/employmentandlabourmarket" aria-expanded="false" aria-label="{{ localise "EmploymentLabourMarket" .Language 1 }} sub menu toggle">
+						<a class="primary-nav__link col col--md-8 col--lg-10" href="/employmentandlabourmarket" aria-expanded="false" aria-label="{{ localise "EmploymentLabourMarket" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle">
 						    <span aria-hidden="true" class="expansion-indicator"></span>
-						    <span aria-label="{{ localise "EmploymentLabourMarket" .Language 1 }} sub menu toggle" role="text" class="submenu-title">
+						    <span aria-label="{{ localise "EmploymentLabourMarket" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle" role="text" class="submenu-title">
 						        {{ localise "EmploymentLabourMarket" .Language 1 }}
                             </span>
                         </a>
@@ -153,9 +153,9 @@
 						</ul>
 					</li>
 					<li class="primary-nav__item js-nav js-expandable ">
-						<a class="primary-nav__link col col--md-8 col--lg-10" href="/peoplepopulationandcommunity" aria-expanded="false" aria-label="{{ localise "PeoplePopulationCommunity" .Language 1 }} sub menu toggle">
+						<a class="primary-nav__link col col--md-8 col--lg-10" href="/peoplepopulationandcommunity" aria-expanded="false" aria-label="{{ localise "PeoplePopulationCommunity" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle">
 						    <span aria-hidden="true" class="expansion-indicator"></span>
-						    <span aria-label="{{ localise "PeoplePopulationCommunity" .Language 1 }} sub menu toggle" role="text" class="submenu-title">
+						    <span aria-label="{{ localise "PeoplePopulationCommunity" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle" role="text" class="submenu-title">
 						        {{ localise "PeoplePopulationCommunity" .Language 1 }}
                             </span>
                         </a>

--- a/assets/templates/partials/header.tmpl
+++ b/assets/templates/partials/header.tmpl
@@ -66,7 +66,12 @@
                       <a class="primary-nav__link col col--md-7 col--lg-9" href="/">{{ localise "Home" .Language 1 }}</a>
                     </li>
                     <li class="primary-nav__item js-nav js-expandable ">
-						<a class="primary-nav__link col col--md-8 col--lg-10" href="/businessindustryandtrade" aria-haspopup="true">{{ localise "BusinessIndustryTrade" .Language 1 }}</a>
+						<a class="primary-nav__link col col--md-8 col--lg-10" href="/businessindustryandtrade" aria-expanded="false" aria-label="{{ localise "BusinessIndustryTrade" .Language 1 }} sub menu toggle">
+						    <span aria-hidden="true" class="expansion-indicator"></span>
+						    <span aria-label="{{ localise "BusinessIndustryTrade" .Language 1 }} sub menu toggle" role="text" class="submenu-title">
+						        {{ localise "BusinessIndustryTrade" .Language 1 }}
+                            </span>
+                        </a>
 						<ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
                             <li class="primary-nav__child-item  js-expandable__child">
 								<a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/business" >{{ localise "Business" .Language 1 }}</a>
@@ -95,7 +100,12 @@
 						</ul>
 					</li>
 					<li class="primary-nav__item js-nav js-expandable ">
-						<a class="primary-nav__link col col--md-8 col--lg-10" href="/economy" aria-haspopup="true">{{ localise "Economy" .Language 1 }}</a>
+						<a class="primary-nav__link col col--md-8 col--lg-10" href="/economy" aria-expanded="false" aria-label="{{ localise "Economy" .Language 1 }} sub menu toggle">
+						    <span aria-hidden="true" class="expansion-indicator"></span>
+						    <span aria-label="{{ localise "Economy" .Language 1 }} sub menu toggle" role="text" class="submenu-title">
+						        {{ localise "Economy" .Language 1 }}
+						    </span>
+						</a>
 						<ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
                             <li class="primary-nav__child-item  js-expandable__child">
 								<a class="primary-nav__child-link" tabindex="-1" href="/economy/economicoutputandproductivity" >{{ localise "EconomicOutputProductivity" .Language 1 }}</a>
@@ -127,7 +137,12 @@
 						</ul>
 					</li>
 					<li class="primary-nav__item js-nav js-expandable ">
-						<a class="primary-nav__link col col--md-8 col--lg-10" href="/employmentandlabourmarket" aria-haspopup="true">{{ localise "EmploymentLabourMarket" .Language 1 }}</a>
+						<a class="primary-nav__link col col--md-8 col--lg-10" href="/employmentandlabourmarket" aria-expanded="false" aria-label="{{ localise "EmploymentLabourMarket" .Language 1 }} sub menu toggle">
+						    <span aria-hidden="true" class="expansion-indicator"></span>
+						    <span aria-label="{{ localise "EmploymentLabourMarket" .Language 1 }} sub menu toggle" role="text" class="submenu-title">
+						        {{ localise "EmploymentLabourMarket" .Language 1 }}
+                            </span>
+                        </a>
 						<ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
 							<li class="primary-nav__child-item  js-expandable__child">
 								<a class="primary-nav__child-link" tabindex="-1" href="/employmentandlabourmarket/peopleinwork" >{{ localise "PeopleInWork" .Language 1 }}</a>
@@ -138,7 +153,12 @@
 						</ul>
 					</li>
 					<li class="primary-nav__item js-nav js-expandable ">
-						<a class="primary-nav__link col col--md-8 col--lg-10" href="/peoplepopulationandcommunity" aria-haspopup="true">{{ localise "PeoplePopulationCommunity" .Language 1 }}</a>
+						<a class="primary-nav__link col col--md-8 col--lg-10" href="/peoplepopulationandcommunity" aria-expanded="false" aria-label="{{ localise "PeoplePopulationCommunity" .Language 1 }} sub menu toggle">
+						    <span aria-hidden="true" class="expansion-indicator"></span>
+						    <span aria-label="{{ localise "PeoplePopulationCommunity" .Language 1 }} sub menu toggle" role="text" class="submenu-title">
+						        {{ localise "PeoplePopulationCommunity" .Language 1 }}
+                            </span>
+                        </a>
 						<ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
                             <li class="primary-nav__child-item  js-expandable__child">
 								<a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/birthsdeathsandmarriages" >{{ localise "BirthsDeathsMarriages" .Language 1 }}</a>

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/6b0bc76"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/e21a0d8"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What

Screen readers (particularly on mobile) were picking up the '+' as a separate link. Added a slightly hacky patch to improve this until the new nav is implemented

### How to review

(Main focus is on iPhone voiceover)
(Requires the PR from sixteens to work correctly https://github.com/ONSdigital/sixteens/pull/222)

- Using a screen reader on a mobile device.
- Go to any page and open the menu.
- Navigate to the first expansion toggle in the menu.
- You should not be able to navigate to the '+'.
- The screen reader should announce the name of the sub menu followed by 'sub menu toggle' and that it is collapsed.
- Expand the sub menu and the screen reader should announce the sub menu is now expanded.
- Navigate to the first item in the sub menu, the screen reader should announce the title of the menu item only.

### Who can review

Anyone but me.
