### PR TITLE
Fix - Reflow - Text overflow in CMD download options

### DIFF
--- a/assets/templates/dataset-filter/preview-page.tmpl
+++ b/assets/templates/dataset-filter/preview-page.tmpl
@@ -109,7 +109,7 @@
                           {{if ne $download.Extension "xls"}}
                             {{if gt (len $download.Size) 0}}
                               <li id="{{$download.Extension}}-item" class="padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix">
-                                <span class="inline-block width--24 padding-top--2">
+                                <span class="inline-block padding-top--2">
                                   {{if eq $download.Extension "txt"}}
                                     Supporting information
                                   {{else}}

--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -53,7 +53,7 @@
               <div class="margin-bottom--2">
                 <ul class="list--neutral">
                 {{range $i, $download := $v.Downloads}}
-                {{if gt (len $download.Size) 0}}{{if gt (len $download.Size) 0}}<li class="padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix"><span class="inline-block width--24 padding-top--2">{{if eq $download.Extension "txt"}}Supporting information{{else}}Complete dataset (<span class="uppercase">{{$download.Extension}}</span> format){{end}}</span>
+                {{if gt (len $download.Size) 0}}{{if gt (len $download.Size) 0}}<li class="padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix"><span class="inline-block padding-top--2">{{if eq $download.Extension "txt"}}Supporting information{{else}}Complete dataset (<span class="uppercase">{{$download.Extension}}</span> format){{end}}</span>
                   <div class="width--12 inline-block float-right text-right"><a id="{{$download.Extension}}-download"                                     data-gtm-download-file="{{$download.URI}}"
                   data-gtm-download-type="{{$download.Extension}}" class="btn btn--primary margin-top--1 margin-bottom--1 margin-right--half width--11" href="{{$download.URI}}"><strong>{{$download.Extension}}</strong> ({{humanSize $download.Size}})</a></div></li>{{end}}{{end}}
                 {{end}}

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/e8b377e"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/5da00b9"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What
Fix CMD download options text overflow by removing text fixed width which does not work at such a small viewport width.

### How to review
1. Visit a CMD dataset page and CMD filtered results page
1. Expand the "Other download options" set the viewport width to 320px
1. See that some of the options overflow
1. Switch to this branch and sixteens branch `fix/reflow-filterered-dataset-download`
1. See that the issues is fixed.

### Who can review
Anyone but me
