### PR TITLE
Fix - Mobile navigation language overflow

### DIFF
--- a/assets/templates/partials/header.tmpl
+++ b/assets/templates/partials/header.tmpl
@@ -203,7 +203,7 @@
                             {{ localise "SurveyTakingPart" .Language 1 }}
                         </a>
                     </li>
-                    <li class="hide--md primary-nav__link">
+                    <li class="hide--md primary-nav__language">
                        {{if eq .Language "cy"}}
                             <a class="language__link icon--hide" href="{{ domainSetLang .SiteDomain .URI "en" }}">{{ localise "EnglishToggle" .Language 1 }}</a> | {{ localise "WelshToggle" .Language 1 }}
                         {{ else }}

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/5da00b9"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/46e1461"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What
When expanding a collapsed menu item in the mobile menu then the language option overflows the menu and ends with nearly white text on white background.

### How to review
1. Visit any page (a babbage or renderer)
1. Expand the menu
1. Expand a collapsed menu item
1. See that language link (at the bottom) has overflowed the menu
1. Switch to branches
    1. Sixteens - `fix/mobile-nav-lang-overflow`
    1. dp-frontend-render- `fix/mobile-nav-lang-overflow`
    1. babbage - `fix/mobile-nav-lang-overflow`
1. See that it is resolved

### Who can review
Anyone but me
