### PR TITLE
Fix - Remove unnecessary role from main nav

### DIFF
--- a/assets/templates/partials/header.tmpl
+++ b/assets/templates/partials/header.tmpl
@@ -68,7 +68,7 @@
                     <li class="primary-nav__item js-nav js-expandable ">
 						<a class="primary-nav__link col col--md-8 col--lg-10" href="/businessindustryandtrade" aria-expanded="false" aria-label="{{ localise "BusinessIndustryTrade" .Language 1 }} {{ localise "SubMenu" .Language 1 }}">
 						    <span aria-hidden="true" class="expansion-indicator"></span>
-						    <span aria-label="{{ localise "BusinessIndustryTrade" .Language 1 }} {{ localise "SubMenu" .Language 1 }}" role="text" class="submenu-title">
+						    <span aria-label="{{ localise "BusinessIndustryTrade" .Language 1 }} {{ localise "SubMenu" .Language 1 }}" class="submenu-title">
 						        {{ localise "BusinessIndustryTrade" .Language 1 }}
                             </span>
                         </a>
@@ -102,7 +102,7 @@
 					<li class="primary-nav__item js-nav js-expandable ">
 						<a class="primary-nav__link col col--md-8 col--lg-10" href="/economy" aria-expanded="false" aria-label="{{ localise "Economy" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle">
 						    <span aria-hidden="true" class="expansion-indicator"></span>
-						    <span aria-label="{{ localise "Economy" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle" role="text" class="submenu-title">
+						    <span aria-label="{{ localise "Economy" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle" class="submenu-title">
 						        {{ localise "Economy" .Language 1 }}
 						    </span>
 						</a>
@@ -139,7 +139,7 @@
 					<li class="primary-nav__item js-nav js-expandable ">
 						<a class="primary-nav__link col col--md-8 col--lg-10" href="/employmentandlabourmarket" aria-expanded="false" aria-label="{{ localise "EmploymentLabourMarket" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle">
 						    <span aria-hidden="true" class="expansion-indicator"></span>
-						    <span aria-label="{{ localise "EmploymentLabourMarket" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle" role="text" class="submenu-title">
+						    <span aria-label="{{ localise "EmploymentLabourMarket" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle" class="submenu-title">
 						        {{ localise "EmploymentLabourMarket" .Language 1 }}
                             </span>
                         </a>
@@ -155,7 +155,7 @@
 					<li class="primary-nav__item js-nav js-expandable ">
 						<a class="primary-nav__link col col--md-8 col--lg-10" href="/peoplepopulationandcommunity" aria-expanded="false" aria-label="{{ localise "PeoplePopulationCommunity" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle">
 						    <span aria-hidden="true" class="expansion-indicator"></span>
-						    <span aria-label="{{ localise "PeoplePopulationCommunity" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle" role="text" class="submenu-title">
+						    <span aria-label="{{ localise "PeoplePopulationCommunity" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle" class="submenu-title">
 						        {{ localise "PeoplePopulationCommunity" .Language 1 }}
                             </span>
                         </a>


### PR DESCRIPTION
### What
Remove unnecessary `role="text"` from main navigation. This was added to fix issue on iPhone VoiceOver but was not actually needed. 

Tested in NVDA and VoiceOver.

### How to review
1. Load any page
1. See that the main navigation links that expand contain a role="text"
1. Switch to this branch and `babbage` branch `fix/misc-remove-unnecessary-role`
1. See that the labels are read correctly by screen readers.

### Who can review
Anyone but me
