### PR TITLE
Fix - Invalid dl on dataset landing pages

### DIFF
--- a/assets/templates/datasetLandingPage/static.tmpl
+++ b/assets/templates/datasetLandingPage/static.tmpl
@@ -76,43 +76,43 @@
 
 <div class="meta-wrap">
     <div class="wrapper">
-        <dl class="col-wrap">
-            <div class="col col--md-12 col--lg-15 meta__item">
+        <ul class="col-wrap meta__list">
+            <li class="col col--md-12 col--lg-15 meta__item">
                 {{ if .DatasetLandingPage.IsNationalStatistic}}
-                    <a href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/">
-                        <img class="meta__image" src="/img/national-statistics.png" alt="This is an accredited National Statistic. Click for information about types of official statistics.">
-                    </a>
+                <a href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/">
+                    <img class="meta__image" src="/img/national-statistics.png" alt="This is an accredited National Statistic. Click for information about types of official statistics.">
+                </a>
                 {{ end }}
-                <dt class="meta__term">{{ localise "Contact" .Language 1  }}</dt>
-                <dd>
+                <div class="meta__term">{{ localise "Contact" .Language 1  }}</div>
+                <div>
                     {{ if .ContactDetails.Email}}
                         <a href="mailto:{{ .ContactDetails.Email}}">{{ .ContactDetails.Name }}</a>
                     {{ else }}
                         {{ .ContactDetails.Name }}
                     {{ end }}
-                </dd>
-            </div>
-            <div class="col col--md-12 col--lg-15 meta__item">
-                <dt class="meta__term">{{ localise "ReleaseDate" .Language 1  }}</dt>
-                <dd>{{ dateFormat .DatasetLandingPage.ReleaseDate }}</dd>
-            </div>
-            <div class="col col--md-12 col--lg-15 meta__item">
-                <dt class="meta__term">{{ localise "NextRelease" .Language 1  }}</dt>
-                <dd>
+                </div>
+            </li>
+            <li class="col col--md-12 col--lg-15 meta__item">
+                <div class="meta__term">{{ localise "ReleaseDate" .Language 1  }}</div>
+                <div>{{ dateFormat .DatasetLandingPage.ReleaseDate }}</div>
+            </li>
+            <li class="col col--md-12 col--lg-15 meta__item">
+                <div class="meta__term">{{ localise "NextRelease" .Language 1  }}</div>
+                <div>
                     {{ if .DatasetLandingPage.NextRelease }}
                         {{ .DatasetLandingPage.NextRelease }}
                     {{ else }}
                         {{ localise "TBA" .Language 1  }}
                     {{ end }}
-                </dd>
-            </div>
-            {{ if .DatasetLandingPage.DatasetID}}
-                <div class="col col--md-12 col--lg-15 meta__item">
-                    <dt class="meta__term">{{ localise "DatasetID" .Language 1  }}</dt>
-                    <dd>{{ .DatasetLandingPage.DatasetID }}</dd>
                 </div>
+            </li>
+            {{ if .DatasetLandingPage.DatasetID}}
+                <li class="col col--md-12 col--lg-15 meta__item">
+                    <div class="meta__term">{{ localise "DatasetID" .Language 1  }}</div>
+                    <div>{{ .DatasetLandingPage.DatasetID }}</div>
+                </li>
             {{ end }}
-        </dl>
+        </ul>
     </div>
 </div>
 

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/cd80c82"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/4d6c6f3"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What
Fix issue on dataset landing page with invalid anchor within a `dl`.

Tried wrapping anchor in div but didn't work 😭 

Change has no noticeable affect to screen readers.

### How to review
1. Load a dataset landing page
1. See there are invalid (non `dt`, `dd` or `div`. Not `a`) elements children of a `dl` (AXE)
1. Switch to this branch and sixteens brach `fix/invalid-dl`
1. See this has been switched to a `ul`, `li` and `div`.

### Who can review
Anyone but me
