### PR TITLE
FIx - Remove duplicate id dataset-version-list page

### DIFF
--- a/assets/templates/datasetLandingPage/version-list.tmpl
+++ b/assets/templates/datasetLandingPage/version-list.tmpl
@@ -32,7 +32,7 @@
                         <summary>
                            <span class="summary underline-link ">Corrections</span>
                         </summary>
-                        <div class="panel padding-top--1 padding-bottom--1 margin-bottom-2" id="details-content-0">
+                        <div class="panel padding-top--1 padding-bottom--1 margin-bottom-2">
                         {{ if .Corrections }}
                            {{ range $i, $correction := .Corrections }}
                               <h3 class="margin-top--1 margin-bottom--2 padding-top--0 padding-bottom--0 font-weight-700">


### PR DESCRIPTION
### What
Remove unnecessary and duplicated id from `dataset-version-list` page.
e.g. https://develop.onsdigital.co.uk/datasets/cpih01/editions/time-series/versions

Haven't been able to see this locally so changing it blind as really tiny.

### How to review
1. Load the page
1. See that there are duplicated ids
1. Switch to this branch
1. See that they are gone

### Who can review
Anyone
