### PR TITLE
Fix - CMD filters duplicate ids

### DIFF
--- a/assets/templates/partials/filter-selection.tmpl
+++ b/assets/templates/partials/filter-selection.tmpl
@@ -10,7 +10,7 @@
   </header>
   <ul class="list list--neutral">
     {{ range .Data.FiltersAdded }}
-    <li><span class="col col--md-36 col--lg-12">{{ .Label }}</span><span class="remove-link js-filter"><a id="{{.ID}}" href="{{ .RemoveURL }}">Remove</a></span></li>
+    <li><span class="col col--md-36 col--lg-12">{{ .Label }}</span><span class="remove-link js-filter"><a data-id="{{.ID}}" href="{{ .RemoveURL }}">Remove</a></span></li>
     {{ end }}
   </ul>
 </div>

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/c8cf65e"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/cd80c82"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What
When adding a filter to the selected filters in CMD hierarchy and geography pages then the ids would be duplicated between input and the remove link.

### How to review
1. Load a CMD hierarchy or geography page
1. Select a filter
1. See that the ids are duplicated
1. Switch to this branch and sixteens `fix/duplicate-ids-cmd-filters`
1. See that there are no ids when added by JS or on refresh

### Who can review
Anyone but me
