### PR TITLE
Fix - Duplicate ids - CMD filters overview page

### DIFF
--- a/assets/templates/dataset-filter/filter-overview.tmpl
+++ b/assets/templates/dataset-filter/filter-overview.tmpl
@@ -24,13 +24,13 @@
                         	    <a class="float-el--right-md float-el--right-sm float-el--right-lg" href="{{.Data.ClearAll.URL}}">Clear filters</a>
                             </li>
                             {{ range .Data.Dimensions}}
-                            <li id="filter-option" class="white-background margin-left-md--2 margin-right-md--2 margin-right-sm--1 margin-left-sm--1 {{if eq .Link.Label "Add"}}filter-overview__add{{else}}filter-overview__edit{{end}}">
+                            <li class="js-filter-option white-background margin-left-md--2 margin-right-md--2 margin-right-sm--1 margin-left-sm--1 {{if eq .Link.Label "Add"}}filter-overview__add{{else}}filter-overview__edit{{end}}">
                                 <div class="col--lg-56 min-height--10 padding-left-sm--0 padding-left-md--1">
                                     {{$length := len .AddedCategories}}{{$categories := .AddedCategories}}
                                     <div class="col col--md-8 col--lg-8 min-height--4">
                                         <a class="{{if eq .Link.Label "Edit"}}filter-overview__link--edit{{else}}filter-overview__link--add{{end}}" href="{{.Link.URL}}"><span class="dimension-button {{if eq .Link.Label "Add"}}btn btn--tertiary margin-left-md--2 margin-left-sm--1 {{else}}margin-left-md--3 margin-left-sm--2 {{end}} font-weight-700 ">{{.Link.Label}} <span class="visuallyhidden">{{if gt $length 0}}by {{end}}{{.Filter}}</span></span></a>
                                     </div>
-                                    <div class="dimension-name col col--md-11 col--lg-14 margin-left-sm--6 height-sm--3 height-md--6 overflow--hidden margin-top-md--3 margin-bottom-sm--2"><strong><span id="filter-option-label" class="font-size--16">{{.Filter}}</span></strong></div>
+                                    <div class="dimension-name col col--md-11 col--lg-14 margin-left-sm--6 height-sm--3 height-md--6 overflow--hidden margin-top-md--3 margin-bottom-sm--2"><strong><span class="js-filter-option-label font-size--16">{{.Filter}}</span></strong></div>
                                     <div id="number-added-{{slug .Filter}}" class="col col--md-20 col--lg-30">
                                         <div class="font-size--16 height-sm--3 height-md--10 nowrap-sm vertical-align-middle margin-left-sm--4 list--ellipses-sm overflow--hidden">
                                         <div class="height-sm--3 max-height-md--9 vertical-align-middle__contents--md list--ellipses-md">

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/4d6c6f3"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/cf2e1ea"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What
Use classes instead of ids as there are multiple filter options on the filters overview page

### How to review
1. Visit the filter overview page for a dataset with multiple filters
1. See that the ids for the list item and text content are duplicated
1. Switch to this branch and sixteens branch `fix/duplicate-ids-cmd-filter-options`
1. See that this issue is now resolved and exiting click and hover functionality is maintained

### Who can review
Anyone but me
