### PR TITLE
add sort to search page

### DIFF
--- a/assets/templates/search.tmpl
+++ b/assets/templates/search.tmpl
@@ -2,5 +2,10 @@
     {{ template "search/bar" . }}
 </div>
 <main id="main" role="main" tabindex="-1">
-    {{ template "search/results" . }}
+    <div class="page-content border">
+        <div class="wrapper">
+            {{ template "search/sort" . }}
+            {{ template "search/results" . }}
+        </div>
+    </div>
 </main>

--- a/assets/templates/search/results.tmpl
+++ b/assets/templates/search/results.tmpl
@@ -1,6 +1,5 @@
-<div class="page-content border">
-    <div class="wrapper">
-        <h1>Search Results</h1>
+<div id="results" class="results">    
+    <div class="search-results ">
         <ul class="list--neutral flush">
             {{ range .Data.Response.Items }}
                 <li class="col col--md-34 col--lg-40 search-results__item">

--- a/assets/templates/search/sort.tmpl
+++ b/assets/templates/search/sort.tmpl
@@ -1,7 +1,7 @@
 <div class="col-wrap print-hidden">
     <div class="col">
         <div class="col col--md-28 col--lg-38">
-            <h2 aria-live="polite" class="search-page__results-text">
+            <h2 aria-live="polite" class="search-page__results-text font-size--16">
                 <span class="stand-out-text">{{ .Data.Response.Count}}</span> 
                 results containing
                 <strong>‘{{ .Data.Query}}’</strong>,
@@ -36,14 +36,14 @@
                     {{end}}
 
                     <div class="js-mobile-filters__sort">
-                        <label for="sort" class="sort__label">Sort by
-                            <select class="input select width-auto js-auto-submit__input" id="sort" name="sort">
+                        <label for="sort" class="sort__label font-size--16">Sort by
+                            <select class="input select width-auto js-auto-submit__input font-size--16" id="sort" name="sort">
                                 <option class="sort__option" value="relevance" {{ if eq .Data.Sort "relevance" }}selected{{end}}>Relevance</option>
                                 <option class="sort__option" value="release_date" {{ if eq .Data.Sort "release_date" }}selected{{end}}>Release date</option>
                                 <option class="sort__option" value="title" {{ if eq .Data.Sort "title" }}selected{{end}}>Title</option>
                             </select>
                         </label>
-                        <button type="submit" class="btn btn--primary btn--thin btn--small js--hide">Sort</button>
+                        <button type="submit" class="btn btn--primary btn--thin btn--small js--hide font-size--16">Sort</button>
                     </div>
                 </form>
             </div>

--- a/assets/templates/search/sort.tmpl
+++ b/assets/templates/search/sort.tmpl
@@ -1,0 +1,52 @@
+<div class="col-wrap print-hidden">
+    <div class="col">
+        <div class="col col--md-28 col--lg-38">
+            <h2 aria-live="polite" class="search-page__results-text">
+                <span class="stand-out-text">{{ .Data.Response.Count}}</span> 
+                results containing
+                <strong>‘{{ .Data.Query}}’</strong>,
+                <span class="lowercase">Sorted by 
+                    <strong>
+                        {{ if .Data.Sort }}
+                            {{ .Data.Sort}}
+                        {{else}}
+                            Relevance 
+                        {{end}} 
+                    </strong>
+                </span>
+                .
+            </h2>
+        </div>
+        <div class="float-right">
+            <div class="sort-results">
+                <form id="form-sort" class="js-auto-submit__form">
+                    
+                    <input type="hidden" name=":uri" value="search">
+                    {{ if .Data.Query }}
+                        <input type="hidden" name="q" value={{ .Data.Query}} class="js-auto-submit__input">
+                    {{end}}
+                    {{ if .Data.Filter }}
+                        <input type="hidden" name="filter" value={{ .Data.Filter}}>
+                    {{end}}
+                    {{ if .Data.Limit }}
+                        <input type="hidden" name="limit" value={{ .Data.Limit}}>
+                    {{end}}
+                    {{ if .Data.Offset }}
+                        <input type="hidden" name="offset" value={{ .Data.Offset}}>
+                    {{end}}
+
+                    <div class="js-mobile-filters__sort">
+                        <label for="sort" class="sort__label">Sort by
+                            <select class="input select width-auto js-auto-submit__input" id="sort" name="sort">
+                                <option class="sort__option" value="relevance" {{ if eq .Data.Sort "relevance" }}selected{{end}}>Relevance</option>
+                                <option class="sort__option" value="release_date" {{ if eq .Data.Sort "release_date" }}selected{{end}}>Release date</option>
+                                <option class="sort__option" value="title" {{ if eq .Data.Sort "title" }}selected{{end}}>Title</option>
+                            </select>
+                        </label>
+                        <button type="submit" class="btn btn--primary btn--thin btn--small js--hide">Sort</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
### What

**Describe what you have changed and why.**
- Add sort bar to the search page
- Able to now sort the search results (without using `babbage`)
- When it is non-js, a sort button is available to do the same functionality

### How to review

**Describe the steps required to test the changes.**
- Check if the code makes sense
- Can test locally by running `web` instances, `dp-search-query`, `dp-frontend-search-controller` and then on the browser, go to `http://localhost:20000/search`
- Search for `housing` for example and then sort the results to `release_date` (or whichever) to see the search results sorted to date order (in this case)

### Who can review

**Describe who worked on the changes, so that other people can review.**
Anyone - Justin made the changes