### PR TITLE
Fix - Geography - Ensure the headings only increment by 1

### DIFF
--- a/assets/templates/geography/list.tmpl
+++ b/assets/templates/geography/list.tmpl
@@ -9,7 +9,7 @@
     {{range $i, $v := .Data.Items}}
         {{if $v.Label}}
             <div class="background--gallery padding-top--2 padding-bottom--2 padding-right--1 padding-left--1 margin-bottom--2">
-                <h3 class="margin-top--0"><a class="area-type" id="area-type-{{$i}}" href="{{$v.URI}}">{{$v.Label}}</a></h3>{{$v.ID}}
+                <h2 class="margin-top--0 font-size--h3"><a class="area-type" id="area-type-{{$i}}" href="{{$v.URI}}">{{$v.Label}}</a></h2>{{$v.ID}}
             </div>
         {{end}}
     {{end}}


### PR DESCRIPTION
### What
Ensure that headings increase by just one. Found using axe

This is a blind (I don't have local data) for the page where this occurrs https://develop.onsdigital.co.uk/geography/countries

### How to review
1. Visit the page (if you can)
1. See the issue mentioned above
1. Switch to this branch
1. See that the issue is resolved and the layout is unchanged

### Who can review
Anyone but me
