### PR TITLE
Fix - Accessibility - CMD Age filter

### DIFF
--- a/assets/templates/dataset-filter/age.tmpl
+++ b/assets/templates/dataset-filter/age.tmpl
@@ -33,11 +33,11 @@
                     <div class="form adjust-font-size--16 clear-left">
                         <div class="col col--md-29 col--lg-29 margin-top--2">
                             <fieldset class="margin-bottom--6">
-                                <legend class="visuallyhidden>Select a method to filter the dataset for Age</legend>
+                                <legend class="visuallyhidden">Select a method to filter the dataset for Age</legend>
                                 {{if .Data.HasAllAges}}
                                 <div class="multiple-choice">
                                     <input id="age-selection-latest" type="radio" class="multiple-choice__input" name="age-selection" value="all" {{if eq .Data.CheckedRadio "all"}}checked{{end}}>
-                                    <label for="age-selection-latest" class="multiple-choice__label">All ages (total)</label>
+                                    <label for="age-selection-latest" class="multiple-choice__label">Add all from the list (Ages {{.Data.Youngest}} to {{.Data.Oldest}} available in this dataset)</label>
                                     <input id="all-ages-option" name="all-ages-option" type="hidden" value="{{.Data.AllAgesOption}}">
                                 </div>
                                 {{end}}


### PR DESCRIPTION
### What
Fix a missing quote and improve label as per UX.

### How to review
1. Visit CMD age filter page
1. See that all ages options does not include min/max age
1. Switch to this branch
1. See that this is resolved

### Who can review
Anyone but me
