### PR TITLE
Fix - Letter spacing

### DIFF
--- a/assets/templates/homepage.tmpl
+++ b/assets/templates/homepage.tmpl
@@ -9,7 +9,7 @@
     </div>
     {{ template "homepage/promos" . }}
     <div class="wrapper background-gallery">
-        <div class="tiles col-wrap">
+        <div class="tiles">
             <div class="tiles__block tiles__block-no-mar-bottom">
                 {{ template "homepage/in-focus" . }}
             </div>

--- a/assets/templates/homepage.tmpl
+++ b/assets/templates/homepage.tmpl
@@ -6,9 +6,8 @@
         <div>
             {{ template "homepage/latest-releases" . }}
         </div>
-        {{ template "homepage/promos" . }}
-
     </div>
+    {{ template "homepage/promos" . }}
     <div class="wrapper background-gallery">
         <div class="tiles col-wrap">
             <div class="tiles__block tiles__block-no-mar-bottom">

--- a/assets/templates/homepage/around-the-ons.tmpl
+++ b/assets/templates/homepage/around-the-ons.tmpl
@@ -1,57 +1,57 @@
 <section>
-    <div class="col">
-        <h1 class="margin-top--0 font-size--h2 font-size--30">{{ localise "AroundTheONS" .Language 1 }}</h2>
+    <h1 class="margin-top--0 font-size--h2 font-size--30">{{ localise "AroundTheONS" .Language 1 }}</h2>
+    <div class="margin--0 flex stretch flex-wrap-wrap margin-bottom--3 content-space-between content-lg--flex-start">
+        <section class="col--md-23 col--lg-14 margin-top--2 flex-basis-sm--full margin-right-lg--1">
+            <article tabindex="0" class="tile tile__highlighted-content">
+                <div class="tile__highlighted-content-image-container">
+                    <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/local-statistics.png" alt="">
+                </div>
+                <h2 class="margin-bottom--0 margin-top--0">
+                    <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/help/localstatistics">
+                        {{ localise "LocalStatisticsTitle" .Language 4 }}
+                    </a>
+                </h2>
+                <p class="tile__text-description margin-top--0">{{ localise "LocalStatisticsSummary" .Language 4 }}</p>
+            </article>
+        </section>
+        <section class="col--md-23 col--lg-14 margin-top--2 flex-basis-sm--full margin-right-lg--1">
+            <article tabindex="0" class="tile tile__highlighted-content">
+                <div class="tile__highlighted-content-image-container">
+                    <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/data-strategy.png" alt="">
+                </div>
+                <h2 class="margin-bottom--0 margin-top--0">
+                    <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/aboutus/transparencyandgovernance/datastrategy">
+                        {{ localise "OurDataStrategyTitle" .Language 4 }}
+                    </a>
+                </h2>
+                <p class="tile__text-description margin-top--0">{{ localise "OurDataStrategySummary" .Language 4 }}</p>
+            </article>
+        </section>
+        <section class="col--md-23 col--lg-14 margin-top--2 flex-basis-sm--full margin-right-lg--1">
+            <article tabindex="0" class="tile tile__highlighted-content">
+                <div class="tile__highlighted-content-image-container">
+                    <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/ons-centres.png" alt="">
+                </div>
+                <h2 class="margin-bottom--0 margin-top--0">
+                    <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/aboutus/whatwedo/programmesandprojects/onscentres">
+                        {{ localise "ONSCentresTitle" .Language 4 }}
+                    </a>
+                </h2>
+                <p class="tile__text-description margin-top--0">{{ localise "ONSCentresSummary" .Language 4 }}</p>
+            </article>
+        </section>
+        <section class="col--md-23 col--lg-14 margin-top--2 flex-basis-sm--full">
+            <article tabindex="0" class="tile tile__highlighted-content">
+                <div class="tile__highlighted-content-image-container">
+                    <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/other-govt-statistics.png" alt="">
+                </div>
+                <h2 class="margin-bottom--0 margin-top--0">
+                    <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.gov.uk/government/statistics">
+                        {{ localise "OtherGovtStatisticsTitle" .Language 4 }}
+                    </a>
+                </h2>
+                <p class="tile__text-description margin-top--0">{{ localise "OtherGovtStatisticsSummary" .Language 4 }}</p>
+            </article>
+        </section>
     </div>
-    <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
-        <article tabindex="0" class="tile tile__highlighted-content">
-            <div class="tile__highlighted-content-image-container">
-                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/local-statistics.png" alt="">
-            </div>
-            <h2 class="margin-bottom--0 margin-top--0">
-                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/help/localstatistics">
-                    {{ localise "LocalStatisticsTitle" .Language 4 }}
-                </a>
-            </h2>
-            <p class="tile__text-description margin-top--0">{{ localise "LocalStatisticsSummary" .Language 4 }}</p>
-        </article>
-    </section>
-    <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
-        <article tabindex="0" class="tile tile__highlighted-content">
-            <div class="tile__highlighted-content-image-container">
-                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/data-strategy.png" alt="">
-            </div>
-            <h2 class="margin-bottom--0 margin-top--0">
-                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/aboutus/transparencyandgovernance/datastrategy">
-                    {{ localise "OurDataStrategyTitle" .Language 4 }}
-                </a>
-            </h2>
-            <p class="tile__text-description margin-top--0">{{ localise "OurDataStrategySummary" .Language 4 }}</p>
-        </article>
-    </section>
-    <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
-        <article tabindex="0" class="tile tile__highlighted-content">
-            <div class="tile__highlighted-content-image-container">
-                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/ons-centres.png" alt="">
-            </div>
-            <h2 class="margin-bottom--0 margin-top--0">
-                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.ons.gov.uk/aboutus/whatwedo/programmesandprojects/onscentres">
-                    {{ localise "ONSCentresTitle" .Language 4 }}
-                </a>
-            </h2>
-            <p class="tile__text-description margin-top--0">{{ localise "ONSCentresSummary" .Language 4 }}</p>
-        </article>
-    </section>
-    <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
-        <article tabindex="0" class="tile tile__highlighted-content">
-            <div class="tile__highlighted-content-image-container">
-                <img class="tile__highlighted-content-image" src="https://cdn.ons.gov.uk/assets/images/around-the-ons/other-govt-statistics.png" alt="">
-            </div>
-            <h2 class="margin-bottom--0 margin-top--0">
-                <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="https://www.gov.uk/government/statistics">
-                    {{ localise "OtherGovtStatisticsTitle" .Language 4 }}
-                </a>
-            </h2>
-            <p class="tile__text-description margin-top--0">{{ localise "OtherGovtStatisticsSummary" .Language 4 }}</p>
-        </article>
-    </section>
 </section>

--- a/assets/templates/homepage/in-focus.tmpl
+++ b/assets/templates/homepage/in-focus.tmpl
@@ -1,20 +1,20 @@
 <section>
-    <div class="col">
-        <h1 class="font-size--h2 font-size--30 margin-top--1">{{ localise "InFocus" .Language 1 }}</h2>
-    </div>
-    {{ range .Data.Featured }}
-        <section class="col col--md-23 col--lg-14 background--white margin-left-md--1 margin-bottom--3">
-            <article tabindex="0" class="tile tile__highlighted-content">
+    <h1 class="font-size--h2 font-size--30 margin-top--1">{{ localise "InFocus" .Language 1 }}</h2>
+    <div class="margin--0 flex stretch flex-wrap-wrap margin-bottom--3 content-space-between content-lg--flex-start">
+    {{ range $i, $v := .Data.Featured }}
+        <section class="tile col--md-23 col--lg-14 flex-basis-sm--full {{if ne $i 3}}margin-right-lg--1{{end}}">
+            <article tabindex="0" class="tile__highlighted-content">
                 <div class="tile__highlighted-content-image-container">
-                    <img class="tile__highlighted-content-image" src="{{if .ImageURL }}{{.ImageURL}}{{else}}https://cdn.ons.gov.uk/assets/images/featured-content-default.svg{{end}}" alt="">
+                    <img class="tile__highlighted-content-image" src="{{if $v.ImageURL }}{{$v.ImageURL}}{{else}}https://cdn.ons.gov.uk/assets/images/featured-content-default.svg{{end}}" alt="">
                 </div>
                 <h2 class="margin-top--0 margin-bottom--0">
                     <a class="margin-left--0 tile__link tile__link--highlighted-content-title font-size--24" href="{{ .URI }}">
-                        {{ .Title }}
+                        {{ $v.Title }}
                     </a>
                 </h2>
-                <p class="tile__text-description margin-top--0">{{ .Description }}</p>
+                <p class="tile__text-description margin-top--0 margin-bottom--0">{{ $v.Description }}</p>
             </article>
         </section>
     {{ end }}
+    </div>
 </section>

--- a/assets/templates/homepage/in-focus.tmpl
+++ b/assets/templates/homepage/in-focus.tmpl
@@ -2,8 +2,8 @@
     <h1 class="font-size--h2 font-size--30 margin-top--1">{{ localise "InFocus" .Language 1 }}</h2>
     <div class="margin--0 flex stretch flex-wrap-wrap margin-bottom--3 content-space-between content-lg--flex-start">
     {{ range $i, $v := .Data.Featured }}
-        <section class="tile col--md-23 col--lg-14 flex-basis-sm--full {{if ne $i 3}}margin-right-lg--1{{end}}">
-            <article tabindex="0" class="tile__highlighted-content">
+        <section class="tile col--md-23 col--lg-14 flex-basis-sm--full {{if ne $i 3}}margin-right-lg--1{{end}}" tabindex="0">
+            <article class="tile__highlighted-content">
                 <div class="tile__highlighted-content-image-container">
                     <img class="tile__highlighted-content-image" src="{{if $v.ImageURL }}{{$v.ImageURL}}{{else}}https://cdn.ons.gov.uk/assets/images/featured-content-default.svg{{end}}" alt="">
                 </div>

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -124,9 +124,9 @@
         </div>
     </div>
     <!--medium-->
-    <div class="col-wrap hide--sm hide--lg">
-        <div class="col col--md-18">
-            <article class="tile tile--employment-figures-stacked margin-left--1">
+    <div class="flex stretch col-wrap hide--sm hide--lg">
+        <div class="col--md-18">
+            <article class="tile margin-left--1">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment</span></h2></header>
                 <section class="col col--md-15">
                     <div class="margin-top--2 tile__subheading">Employment rate</div>
@@ -173,7 +173,7 @@
                 </section>
             </article>
         </div>
-        <div class="col col--md-30">
+        <div class="col--md-30">
             <article class="tile tile__content col col--md-14 margin-left-md--1 margin-bottom-md--2 height-md--52">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Inflation</span></h2></header>
                 {{ if $Inflation.Figure }}

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -5,104 +5,108 @@
 {{ $UnemploymentRate := .Data.MainFigures.MGSX }}
 
 <section>
-    <header><h1 class="col col--lg-12 col--md-12 margin-top--0 margin-bottom--0 margin-right--0 margin-left--0 font-size--30">
-        Main
-        figures</h1><span class="hide--sm font-size--18 line-height--56"> –  </span><span
-            class="margin-left--0 line-height-lg--56 line-height-md--56"><a
-            href="https://www.ons.gov.uk/timeseriestool" class="tile__link">From our time series explorer</a></span>
+    <header>
+        <h1 class="inline font-size--30 margin--0 padding--0">
+            Main figures
+        </h1>
+        <span class="hide--sm font-size--18 line-height--56"> – </span>
+        <span class="margin-left--0 line-height--56">
+            <a href="https://www.ons.gov.uk/timeseriestool" class="tile__link">From our time series explorer</a>
+        </span>
     </header>
     <!--desktop-->
     <div class="hide--sm hide--md-only">
-        <article class="col col--lg-29 col--md-29 tile margin-right--1 height--53">
-            <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment</span></h2></header>
-            <section class="col col--lg-12 margin-right--1">
-                <div class="margin-top--1 tile__subheading">Employment rate</div>
-                {{ if $EmploymentRate.Figure }}
-                    <div class="margin-top-md--2 margin-top-lg--1 height-lg--11">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
-                    <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
+        <div class="flex stretch">
+            <article class="col--lg-29 tile margin-right--1">
+                <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment</span></h2></header>
+                <section class="inline-block col--lg-12 margin-right--1">
+                    <div class="margin-top--1 tile__subheading">Employment rate</div>
+                    {{ if $EmploymentRate.Figure }}
+                        <div class="margin-top-md--2 margin-top-lg--1 height-lg--11">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
+                        <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
+                        <p class="tile__trend">
+                            <span class="tile__trend__icon">
+                                {{if $EmploymentRate.Trend.IsUp}}&uarr;{{ end }}
+                                {{if $EmploymentRate.Trend.IsDown}}&darr;{{ end }}
+                                {{if $EmploymentRate.Trend.IsFlat}}={{ end }}
+                            </span>
+                            <span class="tile__trend__text">{{ $EmploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $EmploymentRate.Trend.Period }}</span>
+                        </p>
+                        <div class="margin-top--2">
+                            <a href="{{ $EmploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for employment rate">Analysis</a>
+                            <a href="{{ $EmploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for employment rate">Data</a>
+                        </div>
+                    {{ else }}
+                        {{ template "homepage/main-figures-error" . }}
+                    {{ end }}
+                </section>
+                <section class="inline-block margin-left--1 col--lg-12">
+                    <div class="margin-top--1 tile__subheading">Unemployment rate</div>
+                    {{ if $UnemploymentRate.Figure }}
+                        <div class="margin-top-md--2 margin-top-lg--1 height-lg--11">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $UnemploymentRate.Date}})</div>
+                        <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
+                        <p class="tile__trend">
+                            <span class="tile__trend__icon">
+                                {{if $UnemploymentRate.Trend.IsUp}}&uarr;{{ end }}
+                                {{if $UnemploymentRate.Trend.IsDown}}&darr;{{ end }}
+                                {{if $UnemploymentRate.Trend.IsFlat}}={{ end }}
+                            </span>
+                            <span class="tile__trend__text">{{ $UnemploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $UnemploymentRate.Trend.Period }}</span>
+                        </p>
+                        <div class="margin-top--2">
+                            <a href="{{ $UnemploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for unemployment rate">Analysis</a>
+                            <a href="{{ $UnemploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for unemployment rate">Data</a>
+                        </div>
+                    {{ else }}
+                        {{ template "homepage/main-figures-error" . }}
+                    {{ end }}
+                </section>
+            </article>
+            <article class="tile tile__content col--lg-14 margin-right--1">
+                <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Inflation</span></h2></header>
+                {{ if $Inflation.Figure }}
+                    <div class="margin-top--1">CPIH 12-month rate</div>
+                    <div class="margin-top--1">{{ DatePeriodFormat $Inflation.Date }}</div>
+                    <div class="tile__figure">{{ $Inflation.Figure }}{{ $Inflation.Unit }}</div>
                     <p class="tile__trend">
                         <span class="tile__trend__icon">
-                            {{if $EmploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                            {{if $EmploymentRate.Trend.IsDown}}&darr;{{ end }}
-                            {{if $EmploymentRate.Trend.IsFlat}}={{ end }}
+                            {{if $Inflation.Trend.IsUp}}&uarr;{{ end }}
+                            {{if $Inflation.Trend.IsDown}}&darr;{{ end }}
+                            {{if $Inflation.Trend.IsFlat}}={{ end }}
                         </span>
-                        <span class="tile__trend__text">{{ $EmploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $EmploymentRate.Trend.Period }}</span>
+                        <span class="tile__trend__text">{{ $Inflation.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $Inflation.Trend.Period }}</span>
                     </p>
                     <div class="margin-top--2">
-                        <a href="{{ $EmploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for employment rate">Analysis</a>
-                        <a href="{{ $EmploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for employment rate">Data</a>
+                    <a href="{{ $Inflation.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for inflation">Analysis</a>
+                        <a href="{{ $Inflation.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for inflation">Data</a>
                     </div>
                 {{ else }}
                     {{ template "homepage/main-figures-error" . }}
                 {{ end }}
-            </section>
-            <div class="col tile__split-bar print--hide hide--md hide--lg"></div>
-            <section class="col margin-left--1 col--lg-12">
-                <div class="margin-top--1 tile__subheading">Unemployment rate</div>
-                {{ if $UnemploymentRate.Figure }}
-                    <div class="margin-top-md--2 margin-top-lg--1 height-lg--11">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $UnemploymentRate.Date}})</div>
-                    <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
+            </article>
+            <article class="tile tile__content col--lg-14 margin-top--2">
+                <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">GDP</span></h2></header>
+                {{ if $GDP.Figure }}
+                    <div class="margin-top--1">Quarter on Quarter</div>
+                    <div class="margin-top--1">{{ DatePeriodFormat $GDP.Date }}</div>
+                    <div class="tile__figure">{{ $GDP.Figure }}{{ $GDP.Unit}}</div>
                     <p class="tile__trend">
                         <span class="tile__trend__icon">
-                            {{if $UnemploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                            {{if $UnemploymentRate.Trend.IsDown}}&darr;{{ end }}
-                            {{if $UnemploymentRate.Trend.IsFlat}}={{ end }}
+                            {{if $GDP.Trend.IsUp}}&uarr;{{ end }}
+                            {{if $GDP.Trend.IsDown}}&darr;{{ end }}
+                            {{if $GDP.Trend.IsFlat}}={{ end }}
                         </span>
-                        <span class="tile__trend__text">{{ $UnemploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $UnemploymentRate.Trend.Period }}</span>
+                        <span class="tile__trend__text">{{ $GDP.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $GDP.Trend.Period }}</span>
                     </p>
                     <div class="margin-top--2">
-                        <a href="{{ $UnemploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for unemployment rate">Analysis</a>
-                        <a href="{{ $UnemploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for unemployment rate">Data</a>
+                        <a href="{{ $GDP.FigureURIs.Analysis}}" class="tile__link" aria-label="Analysis for GDP">Analysis</a>
+                        <a href="{{ $GDP.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for GDP">Data</a>
                     </div>
                 {{ else }}
                     {{ template "homepage/main-figures-error" . }}
                 {{ end }}
-            </section>
-        </article>
-        <article class="tile tile__content col col--lg-14 col--md-14 margin-right--1 height--53">
-            <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Inflation</span></h2></header>
-            {{ if $Inflation.Figure }}
-                <div class="margin-top--1">CPIH 12-month rate</div>
-                <div class="margin-top--1">{{ DatePeriodFormat $Inflation.Date }}</div>
-                <div class="tile__figure">{{ $Inflation.Figure }}{{ $Inflation.Unit }}</div>
-                <p class="tile__trend">
-                    <span class="tile__trend__icon">
-                        {{if $Inflation.Trend.IsUp}}&uarr;{{ end }}
-                        {{if $Inflation.Trend.IsDown}}&darr;{{ end }}
-                        {{if $Inflation.Trend.IsFlat}}={{ end }}
-                    </span>
-                    <span class="tile__trend__text">{{ $Inflation.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $Inflation.Trend.Period }}</span>
-                </p>
-                <div class="margin-top--2">
-                <a href="{{ $Inflation.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for inflation">Analysis</a>
-                    <a href="{{ $Inflation.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for inflation">Data</a>
-                </div>
-            {{ else }}
-                {{ template "homepage/main-figures-error" . }}
-            {{ end }}
-        </article>
-        <article class="tile tile__content col col--lg-14 col--md-14 margin-top-md--2 margin-top-lg--2 height--53">
-            <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">GDP</span></h2></header>
-            {{ if $GDP.Figure }}
-                <div class="margin-top--1">Quarter on Quarter</div>
-                <div class="margin-top--1">{{ DatePeriodFormat $GDP.Date }}</div>
-                <div class="tile__figure">{{ $GDP.Figure }}{{ $GDP.Unit}}</div>
-                <p class="tile__trend">
-                    <span class="tile__trend__icon">
-                        {{if $GDP.Trend.IsUp}}&uarr;{{ end }}
-                        {{if $GDP.Trend.IsDown}}&darr;{{ end }}
-                        {{if $GDP.Trend.IsFlat}}={{ end }}
-                    </span>   
-                    <span class="tile__trend__text">{{ $GDP.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $GDP.Trend.Period }}</span>
-                </p>
-                <div class="margin-top--2">
-                    <a href="{{ $GDP.FigureURIs.Analysis}}" class="tile__link" aria-label="Analysis for GDP">Analysis</a>
-                    <a href="{{ $GDP.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for GDP">Data</a>
-                </div>
-            {{ else }}
-                {{ template "homepage/main-figures-error" . }}
-            {{ end }}
-        </article>
+            </article>
+        </div>
         <div class="col col--lg-29 col--md-29">
             <article class="tile tile__content margin-top-lg--2 margin-top-md--2 margin-left-md--1 margin-left-lg--0 height-lg--31">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">UK population</span></h2></header>

--- a/assets/templates/homepage/promos.tmpl
+++ b/assets/templates/homepage/promos.tmpl
@@ -1,10 +1,8 @@
-<div class="wrapper padding-left--0 padding-right--0 background-gallery">
-    <div class="tiles margin-top-sm--5 col-wrap">
-        <div class="col col--md-23 margin-left-md--1 margin-left-lg--1 col--lg-29 background--white margin-bottom--0 margin-top-sm--4 margin-top-md--3 margin-top-lg--3">
-            {{ template "partials/banners/survey" . }}
-        </div>
-        <div class="col col--md-23 col--lg-29 background--white margin-left-md--1 margin-left-lg--1 margin-bottom--0 margin-top-sm--1 margin-top-md--3 margin-top-lg--3">
-            {{ template "partials/banners/census" . }}
-        </div>
+<div class="flex wrapper flex-wrap-wrap stretch tiles background-gallery margin-top--2 margin-bottom--2">
+    <div class="col--md-23 col--lg-29 margin-right-md--1 margin-bottom-sm--2 flex-basis-sm--full">
+        {{ template "partials/banners/survey" . }}
+    </div>
+    <div class="col--md-23 col--lg-29 flex-basis-sm--full">
+        {{ template "partials/banners/census" . }}
     </div>
 </div>

--- a/assets/templates/partials/banners/census.tmpl
+++ b/assets/templates/partials/banners/census.tmpl
@@ -1,6 +1,6 @@
 <a class="promo__container" href="/census">
-    <section class="promo__background--plum-gradient box__content box__content--homepage height-sm--18 height-md--22 height-lg--14 padding-top-sm--2 padding-top-md--2 padding-top-lg--2 margin-bottom--2">
-        <div class="promo__copy promo__body--column padding-left--1">
+    <section class="promo__background--plum-gradient box__content box__content--homepage padding-top-sm--2 padding-top-md--2 margin-bottom--2">
+        <div class="promo__copy promo__body--column padding-left--1 padding-right--1 padding-top--2 padding-bottom--2">
             <img class="padding-top--1 padding-bottom-md--1" alt="Census 2021" src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape.svg">
             <p class="padding-top-lg--0 padding-top-sm--2 padding-top-md--3 promo__description margin-top--0 margin-bottom--0 padding-right--1 underline-link">
                 {{ localise "CensusBannerBody" .Language 1 }}

--- a/assets/templates/partials/banners/census.tmpl
+++ b/assets/templates/partials/banners/census.tmpl
@@ -1,5 +1,5 @@
 <a class="promo__container" href="/census">
-    <section class="promo__background--plum-gradient box__content box__content--homepage padding-top-sm--2 padding-top-md--2 margin-bottom--2">
+    <section class="promo__background--plum-gradient box__content box__content--homepage">
         <div class="promo__copy promo__body--column padding-left--1 padding-right--1 padding-top--2 padding-bottom--2">
             <img class="padding-top--1 padding-bottom-md--1" alt="Census 2021" src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape.svg">
             <p class="padding-top-lg--0 padding-top-sm--2 padding-top-md--3 promo__description margin-top--0 margin-bottom--0 padding-right--1 underline-link">

--- a/assets/templates/partials/banners/survey.tmpl
+++ b/assets/templates/partials/banners/survey.tmpl
@@ -1,6 +1,6 @@
 <a class="promo__container" href="/surveys">
-    <section class="promo__background--blue-gradient box__content box__content--homepage height-sm--14 height-md--22 height-lg--14 margin-bottom--2">
-        <div class="promo__body padding-right--1 padding-top-md--2">
+    <section class="promo__background--blue-gradient box__content box__content--homepage">
+        <div class="promo__body padding-left--1 padding-right--1 padding-top--2 padding-bottom--2">
             <img class="hide--md-only" src="https://cdn.ons.gov.uk/assets/images/icon-checkbox.svg" alt="">
             <div class="promo__copy">
                 <h2 class="promo__heading margin-top--0 padding-top--0 padding-bottom-sm--0 padding-bottom-md--0 padding-bottom-lg--1">{{ localise "SurveyTakingPart" .Language 1 }}</h2>

--- a/assets/templates/partials/header.tmpl
+++ b/assets/templates/partials/header.tmpl
@@ -60,158 +60,156 @@
                 </li>
                 {{end}}
             </ul>
-            <div class="wrapper nav-main--hidden" id="nav-primary" aria-expanded="false">
-                <ul class="primary-nav__list">
-                    <li class="primary-nav__item {{if eq .URI "/"}}primary-nav__item--active{{end}} js-nav hide--sm old-ie--display-block">
-                      <a class="primary-nav__link col col--md-7 col--lg-9" href="/">{{ localise "Home" .Language 1 }}</a>
-                    </li>
-                    <li class="primary-nav__item js-nav js-expandable ">
-						<a class="primary-nav__link col col--md-8 col--lg-10" href="/businessindustryandtrade" aria-expanded="false" aria-label="{{ localise "BusinessIndustryTrade" .Language 1 }} {{ localise "SubMenu" .Language 1 }}">
-						    <span aria-hidden="true" class="expansion-indicator"></span>
-						    <span aria-label="{{ localise "BusinessIndustryTrade" .Language 1 }} {{ localise "SubMenu" .Language 1 }}" class="submenu-title">
-						        {{ localise "BusinessIndustryTrade" .Language 1 }}
-                            </span>
-                        </a>
-						<ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/business" >{{ localise "Business" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/changestobusiness" >{{ localise "ChangesToBusiness" .Language 1 }}</a>
-							</li>
-							<li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/constructionindustry" >{{ localise "ConstructionIndustry" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/itandinternetindustry" >{{ localise "ITInternetIndustry" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/internationaltrade" >{{ localise "InternationalTrade" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/manufacturingandproductionindustry" >{{ localise "ManufacturingProductionIndustry" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/retailindustry" >{{ localise "RetailIndustry" .Language 1 }}</a>
-							</li>
-							<li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/tourismindustry" >{{ localise "TourismIndustry" .Language 1 }}</a>
-							</li>
-						</ul>
-					</li>
-					<li class="primary-nav__item js-nav js-expandable ">
-						<a class="primary-nav__link col col--md-8 col--lg-10" href="/economy" aria-expanded="false" aria-label="{{ localise "Economy" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle">
-						    <span aria-hidden="true" class="expansion-indicator"></span>
-						    <span aria-label="{{ localise "Economy" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle" class="submenu-title">
-						        {{ localise "Economy" .Language 1 }}
-						    </span>
-						</a>
-						<ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/economy/economicoutputandproductivity" >{{ localise "EconomicOutputProductivity" .Language 1 }}</a>
-							</li>
-							<li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/economy/environmentalaccounts" >{{ localise "EnvironmentalAccounts" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/economy/governmentpublicsectorandtaxes" >{{ localise "GovernmentPublicSectorTaxes" .Language 1 }}</a>
-							</li>
-							<li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/economy/grossdomesticproductgdp" >{{ localise "GrossDomesticProduct" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/economy/grossvalueaddedgva" >{{ localise "GrossDomesticValue" .Language 1 }}</a>
-							</li>
-							<li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/economy/inflationandpriceindices" >{{ localise "InflationPriceIndices" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/economy/investmentspensionsandtrusts" >{{ localise "InvestmentsPensionsTrusts" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/economy/nationalaccounts" >{{ localise "NationalAccounts" .Language 1 }}</a>
-							</li>
-							<li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/economy/regionalaccounts" >{{ localise "RegionalAccounts" .Language 1 }}</a>
-							</li>
-						</ul>
-					</li>
-					<li class="primary-nav__item js-nav js-expandable ">
-						<a class="primary-nav__link col col--md-8 col--lg-10" href="/employmentandlabourmarket" aria-expanded="false" aria-label="{{ localise "EmploymentLabourMarket" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle">
-						    <span aria-hidden="true" class="expansion-indicator"></span>
-						    <span aria-label="{{ localise "EmploymentLabourMarket" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle" class="submenu-title">
-						        {{ localise "EmploymentLabourMarket" .Language 1 }}
-                            </span>
-                        </a>
-						<ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
-							<li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/employmentandlabourmarket/peopleinwork" >{{ localise "PeopleInWork" .Language 1 }}</a>
-							</li>
-							<li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/employmentandlabourmarket/peoplenotinwork" >{{ localise "PeopleNotInWork" .Language 1 }}</a>
-							</li>
-						</ul>
-					</li>
-					<li class="primary-nav__item js-nav js-expandable ">
-						<a class="primary-nav__link col col--md-8 col--lg-10" href="/peoplepopulationandcommunity" aria-expanded="false" aria-label="{{ localise "PeoplePopulationCommunity" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle">
-						    <span aria-hidden="true" class="expansion-indicator"></span>
-						    <span aria-label="{{ localise "PeoplePopulationCommunity" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle" class="submenu-title">
-						        {{ localise "PeoplePopulationCommunity" .Language 1 }}
-                            </span>
-                        </a>
-						<ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/birthsdeathsandmarriages" >{{ localise "BirthsDeathsMarriages" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/crimeandjustice" >{{ localise "CrimeJustice" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/culturalidentity" >{{ localise "CulturalIdentity" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/educationandchildcare" >{{ localise "EducationChildcare" .Language 1 }}</a>
-							</li>
-							<li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/elections" >{{ localise "Elections" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/healthandsocialcare" >{{ localise "HealthSocialCare" .Language 1 }}</a>
-							</li>
-							<li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/householdcharacteristics" >{{ localise "HouseholdCharacteristics" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/housing" >{{ localise "Housing" .Language 1 }}</a>
-							</li>
-							<li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/leisureandtourism" >{{ localise "LeisureTourism" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/personalandhouseholdfinances" >{{ localise "PersonalHouseholdFinances" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/populationandmigration" >{{ localise "PopulationMigration" .Language 1 }}</a>
-							</li>
-                            <li class="primary-nav__child-item  js-expandable__child">
-								<a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/wellbeing" >{{ localise "Wellbeing" .Language 1 }}</a>
-							</li>
-						</ul>
-					</li>
-                    <li class="primary-nav__item js-nav">
-                        <a class="primary-nav__link  col col--md-8 col--lg-10" href="/surveys">
-                            {{ localise "SurveyTakingPart" .Language 1 }}
-                        </a>
-                    </li>
-                    <li class="hide--md primary-nav__language">
-                       {{if eq .Language "cy"}}
-                            <a class="language__link icon--hide" href="{{ domainSetLang .SiteDomain .URI "en" }}">{{ localise "EnglishToggle" .Language 1 }}</a> | {{ localise "WelshToggle" .Language 1 }}
-                        {{ else }}
-                            {{ localise "EnglishToggle" .Language 1 }} | <a class="language__link icon--hide" href="{{ domainSetLang .SiteDomain .URI "cy" }}">{{ localise "WelshToggle" .Language 1 }}</a>
-                    {{end}}
-                    </li>
-                </ul>
-            </div>
+            <ul class="wrapper nav-main--hidden primary-nav__list" id="nav-primary" aria-expanded="false">
+                <li class="primary-nav__item {{if eq .URI "/"}}primary-nav__item--active{{end}} js-nav hide--sm old-ie--display-block">
+                    <a class="primary-nav__link col col--md-7 col--lg-9" href="/">{{ localise "Home" .Language 1 }}</a>
+                </li>
+                <li class="primary-nav__item js-nav js-expandable ">
+                    <a class="primary-nav__link col col--md-8 col--lg-10" href="/businessindustryandtrade" aria-expanded="false" aria-label="{{ localise "BusinessIndustryTrade" .Language 1 }} {{ localise "SubMenu" .Language 1 }}">
+                        <span aria-hidden="true" class="expansion-indicator"></span>
+                        <span aria-label="{{ localise "BusinessIndustryTrade" .Language 1 }} {{ localise "SubMenu" .Language 1 }}" class="submenu-title">
+                            {{ localise "BusinessIndustryTrade" .Language 1 }}
+                        </span>
+                    </a>
+                    <ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/business" >{{ localise "Business" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/changestobusiness" >{{ localise "ChangesToBusiness" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/constructionindustry" >{{ localise "ConstructionIndustry" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/itandinternetindustry" >{{ localise "ITInternetIndustry" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/internationaltrade" >{{ localise "InternationalTrade" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/manufacturingandproductionindustry" >{{ localise "ManufacturingProductionIndustry" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/retailindustry" >{{ localise "RetailIndustry" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/businessindustryandtrade/tourismindustry" >{{ localise "TourismIndustry" .Language 1 }}</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="primary-nav__item js-nav js-expandable ">
+                    <a class="primary-nav__link col col--md-8 col--lg-10" href="/economy" aria-expanded="false" aria-label="{{ localise "Economy" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle">
+                        <span aria-hidden="true" class="expansion-indicator"></span>
+                        <span aria-label="{{ localise "Economy" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle" class="submenu-title">
+                            {{ localise "Economy" .Language 1 }}
+                        </span>
+                    </a>
+                    <ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/economy/economicoutputandproductivity" >{{ localise "EconomicOutputProductivity" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/economy/environmentalaccounts" >{{ localise "EnvironmentalAccounts" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/economy/governmentpublicsectorandtaxes" >{{ localise "GovernmentPublicSectorTaxes" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/economy/grossdomesticproductgdp" >{{ localise "GrossDomesticProduct" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/economy/grossvalueaddedgva" >{{ localise "GrossDomesticValue" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/economy/inflationandpriceindices" >{{ localise "InflationPriceIndices" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/economy/investmentspensionsandtrusts" >{{ localise "InvestmentsPensionsTrusts" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/economy/nationalaccounts" >{{ localise "NationalAccounts" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/economy/regionalaccounts" >{{ localise "RegionalAccounts" .Language 1 }}</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="primary-nav__item js-nav js-expandable ">
+                    <a class="primary-nav__link col col--md-8 col--lg-10" href="/employmentandlabourmarket" aria-expanded="false" aria-label="{{ localise "EmploymentLabourMarket" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle">
+                        <span aria-hidden="true" class="expansion-indicator"></span>
+                        <span aria-label="{{ localise "EmploymentLabourMarket" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle" class="submenu-title">
+                            {{ localise "EmploymentLabourMarket" .Language 1 }}
+                        </span>
+                    </a>
+                    <ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/employmentandlabourmarket/peopleinwork" >{{ localise "PeopleInWork" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/employmentandlabourmarket/peoplenotinwork" >{{ localise "PeopleNotInWork" .Language 1 }}</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="primary-nav__item js-nav js-expandable ">
+                    <a class="primary-nav__link col col--md-8 col--lg-10" href="/peoplepopulationandcommunity" aria-expanded="false" aria-label="{{ localise "PeoplePopulationCommunity" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle">
+                        <span aria-hidden="true" class="expansion-indicator"></span>
+                        <span aria-label="{{ localise "PeoplePopulationCommunity" .Language 1 }} {{ localise "SubMenu" .Language 1 }} toggle" class="submenu-title">
+                            {{ localise "PeoplePopulationCommunity" .Language 1 }}
+                        </span>
+                    </a>
+                    <ul class="primary-nav__child-list col col--md-16 col--lg-20 js-expandable__content js-nav-hidden jsEnhance" aria-expanded="false" aria-label="submenu">
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/birthsdeathsandmarriages" >{{ localise "BirthsDeathsMarriages" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/crimeandjustice" >{{ localise "CrimeJustice" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/culturalidentity" >{{ localise "CulturalIdentity" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/educationandchildcare" >{{ localise "EducationChildcare" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/elections" >{{ localise "Elections" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/healthandsocialcare" >{{ localise "HealthSocialCare" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/householdcharacteristics" >{{ localise "HouseholdCharacteristics" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/housing" >{{ localise "Housing" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/leisureandtourism" >{{ localise "LeisureTourism" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/personalandhouseholdfinances" >{{ localise "PersonalHouseholdFinances" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/populationandmigration" >{{ localise "PopulationMigration" .Language 1 }}</a>
+                        </li>
+                        <li class="primary-nav__child-item  js-expandable__child">
+                            <a class="primary-nav__child-link" tabindex="-1" href="/peoplepopulationandcommunity/wellbeing" >{{ localise "Wellbeing" .Language 1 }}</a>
+                        </li>
+                    </ul>
+                </li>
+                <li class="primary-nav__item js-nav">
+                    <a class="primary-nav__link  col col--md-8 col--lg-10" href="/surveys">
+                        {{ localise "SurveyTakingPart" .Language 1 }}
+                    </a>
+                </li>
+                <li class="hide--md primary-nav__language">
+                    {{if eq .Language "cy"}}
+                        <a class="language__link icon--hide" href="{{ domainSetLang .SiteDomain .URI "en" }}">{{ localise "EnglishToggle" .Language 1 }}</a> | {{ localise "WelshToggle" .Language 1 }}
+                    {{ else }}
+                        {{ localise "EnglishToggle" .Language 1 }} | <a class="language__link icon--hide" href="{{ domainSetLang .SiteDomain .URI "cy" }}">{{ localise "WelshToggle" .Language 1 }}</a>
+                {{end}}
+                </li>
+            </ul>
         </nav>
     </div>
     {{if not .SearchDisabled}}

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/cf2e1ea"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/ce1778d"
 	}
 	return cfg, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/ce1778d"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/1697d8d"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What
Completely rework the homepage styling to remove fixed heights so that when the letter spacing is changed the content expands and the content is not obscured.

One known issue is that there is some unintended spacing on the tablet (breakpoint md) when the text spacing is there. This seems unavoidable without JS which seems unnecessary. This has been signed off by @armstrongb  

This works on all supported browsers.

### How to review
1. Visit any page
1. Run the letter spacing bookmarklet
1. See that content is obscured or the design is broken
1. Switch to this branch, dp-frontend-renderer branch  `fix/letter-spacing-homepage` and babbage branch `fix/letter-spacing`

### Who can review
Anyone but me
