### PR TITLE
make text float left on mobile

### DIFF
--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -54,7 +54,7 @@
                 <ul class="list--neutral">
                 {{range $i, $download := $v.Downloads}}
                 {{if gt (len $download.Size) 0}}{{if gt (len $download.Size) 0}}<li class="padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix"><span class="inline-block padding-top--2">{{if eq $download.Extension "txt"}}Supporting information{{else}}Complete dataset (<span class="uppercase">{{$download.Extension}}</span> format){{end}}</span>
-                  <div class="width--12 inline-block float-right text-right"><a id="{{$download.Extension}}-download"                                     data-gtm-download-file="{{$download.URI}}"
+                  <div class="width--12 inline-block float-right text-right float-left-mobile"><a id="{{$download.Extension}}-download"                                     data-gtm-download-file="{{$download.URI}}"
                   data-gtm-download-type="{{$download.Extension}}" class="btn btn--primary margin-top--1 margin-bottom--1 margin-right--half width--11" href="{{$download.URI}}"><strong>{{$download.Extension}}</strong> ({{humanSize $download.Size}})</a></div></li>{{end}}{{end}}
                 {{end}}
                 </ul>

--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -54,7 +54,7 @@
                 <ul class="list--neutral">
                 {{range $i, $download := $v.Downloads}}
                 {{if gt (len $download.Size) 0}}{{if gt (len $download.Size) 0}}<li class="padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix"><span class="inline-block padding-top--2">{{if eq $download.Extension "txt"}}Supporting information{{else}}Complete dataset (<span class="uppercase">{{$download.Extension}}</span> format){{end}}</span>
-                  <div class="width--12 inline-block float-right text-right"><a id="{{$download.Extension}}-download"                                     data-gtm-download-file="{{$download.URI}}"
+                  <div class="width--12 inline-block float-right text-right float-el--left-sm text-left"><a id="{{$download.Extension}}-download"                                     data-gtm-download-file="{{$download.URI}}"
                   data-gtm-download-type="{{$download.Extension}}" class="btn btn--primary margin-top--1 margin-bottom--1 margin-right--half width--11" href="{{$download.URI}}"><strong>{{$download.Extension}}</strong> ({{humanSize $download.Size}})</a></div></li>{{end}}{{end}}
                 {{end}}
                 </ul>

--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -54,7 +54,7 @@
                 <ul class="list--neutral">
                 {{range $i, $download := $v.Downloads}}
                 {{if gt (len $download.Size) 0}}{{if gt (len $download.Size) 0}}<li class="padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix"><span class="inline-block padding-top--2">{{if eq $download.Extension "txt"}}Supporting information{{else}}Complete dataset (<span class="uppercase">{{$download.Extension}}</span> format){{end}}</span>
-                  <div class="width--12 inline-block float-right text-right float-left-mobile"><a id="{{$download.Extension}}-download"                                     data-gtm-download-file="{{$download.URI}}"
+                  <div class="width--12 inline-block float-right text-right"><a id="{{$download.Extension}}-download"                                     data-gtm-download-file="{{$download.URI}}"
                   data-gtm-download-type="{{$download.Extension}}" class="btn btn--primary margin-top--1 margin-bottom--1 margin-right--half width--11" href="{{$download.URI}}"><strong>{{$download.Extension}}</strong> ({{humanSize $download.Size}})</a></div></li>{{end}}{{end}}
                 {{end}}
                 </ul>

--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -54,7 +54,7 @@
                 <ul class="list--neutral">
                 {{range $i, $download := $v.Downloads}}
                 {{if gt (len $download.Size) 0}}{{if gt (len $download.Size) 0}}<li class="padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix"><span class="inline-block padding-top--2">{{if eq $download.Extension "txt"}}Supporting information{{else}}Complete dataset (<span class="uppercase">{{$download.Extension}}</span> format){{end}}</span>
-                  <div class="width--12 inline-block float-right text-right float-el--left-sm text-left"><a id="{{$download.Extension}}-download"                                     data-gtm-download-file="{{$download.URI}}"
+                  <div class="width--12 inline-block float-right float-el--left-sm text-left--sm"><a id="{{$download.Extension}}-download"                                     data-gtm-download-file="{{$download.URI}}"
                   data-gtm-download-type="{{$download.Extension}}" class="btn btn--primary margin-top--1 margin-bottom--1 margin-right--half width--11" href="{{$download.URI}}"><strong>{{$download.Extension}}</strong> ({{humanSize $download.Size}})</a></div></li>{{end}}{{end}}
                 {{end}}
                 </ul>

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/5f9b003"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/d3061e9"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What

Inside the other download options box, the text was floating right on mobile devices and looked awkward. Text now floats left. 

### How to review

Go here: http://localhost:20000/datasets/cpih01/editions/time-series/versions/1
See that on mobile view, the text in the other download options box is floating right. 
Pull this branch and the text should be left aligned. 

### Who can review

Anyone but me. 
