### PR TITLE
update to exclude margin on end of row for up to 8 tiles

### DIFF
--- a/assets/templates/homepage/in-focus.tmpl
+++ b/assets/templates/homepage/in-focus.tmpl
@@ -2,7 +2,7 @@
     <h1 class="font-size--h2 font-size--30 margin-top--1">{{ localise "InFocus" .Language 1 }}</h2>
     <div class="margin--0 flex stretch flex-wrap-wrap margin-bottom--3 content-space-between content-lg--flex-start">
     {{ range $i, $v := .Data.Featured }}
-        <section class="tile col--md-23 col--lg-14 flex-basis-sm--full {{if ne $i 3}}margin-right-lg--1{{end}}" tabindex="0">
+        <section class="tile col--md-23 col--lg-14 flex-basis-sm--full {{if (and (ne $i 3) (ne $i 7)) -}}margin-right-lg--1{{end}}" tabindex="0">
             <article class="tile__highlighted-content">
                 <div class="tile__highlighted-content-image-container">
                     <img class="tile__highlighted-content-image" src="{{if $v.ImageURL }}{{$v.ImageURL}}{{else}}https://cdn.ons.gov.uk/assets/images/featured-content-default.svg{{end}}" alt="">


### PR DESCRIPTION
### What

Update number of maximum tiles in the In Focus section from 4 to 8. This means publishing can provide more content to the In Focus section on the homepage.

### How to review

- Update your homepage data.json to include _up to_ 8 objects. The updated logic in the template file should ensure that the In Focus tiles are laid out properly

- You could also test in Florence with [this PR]() that the limit has been increased to 8 in the Edit Homepage screen too. It'd then be a case of following the full Edit Homepage publishing journey and viewing the changes afterwards.

### Who can review

Anyone
