### PR TITLE
Revert a revert with 2 added lines

### DIFF
--- a/assets/templates/dataset-filter/time.tmpl
+++ b/assets/templates/dataset-filter/time.tmpl
@@ -41,6 +41,8 @@
                                     <input type="hidden" name="latest-option" value="{{.Data.LatestTime.Option}}">
                                     <input type="hidden" name="latest-month" id="lastest-month" value="{{.Data.LatestTime.Month}}">
                                     <input type="hidden" name="latest-year" id="latest-year" value="{{.Data.LatestTime.Year}}">
+                                    <input type="hidden" name="first-year" id="first-year" value="{{.Data.FirstTime.Year}}">
+                                    <input type="hidden" name="first-month" id="first-month" value="{{.Data.FirstTime.Month}}">
                                 </div>
                                 <div class="multiple-choice">
                                     <input id="time-selection-single" type="radio" class="multiple-choice__input" name="time-selection" value="single" {{if eq .Data.CheckedRadio "single"}}checked{{end}}>

--- a/assets/templates/dataset-filter/time.tmpl
+++ b/assets/templates/dataset-filter/time.tmpl
@@ -52,9 +52,9 @@
                                                     <label class="block margin-bottom--1" for="month-single">Month</label>
                                                     <div class="select-alt">
                                                         <select class="select width-sm--10 width-md--10 width-lg--10" name="month-single" id="month-single">
-                                                        {{ range $.Data.Months }}
+                                                            {{ range $.Data.Months }}
                                                             <option value="{{.}}" {{if eq $.Data.CheckedRadio "single"}}{{if eq . $.Data.SelectedStartMonth}}selected{{end}}{{end}}>{{.}}</option>
-                                                        {{ end }}
+                                                            {{ end }}
                                                         </select>
                                                     </div>
                                                 </div>
@@ -62,9 +62,9 @@
                                                     <label class="block margin-bottom--1" for="year-single">Year</label>
                                                     <div class="select-alt">
                                                         <select class="select width-sm--10 width-md--10 width-lg--10" name="year-single" id="year-single">
-                                                        {{ range $.Data.Years }}
+                                                            {{ range $.Data.Years }}
                                                             <option value="{{.}}" {{if eq $.Data.CheckedRadio "single"}}{{if eq . $.Data.SelectedStartYear}}selected{{end}}{{end}}>{{.}}</option>
-                                                        {{ end }}
+                                                            {{ end }}
                                                         </select>
                                                     </div>
                                                 </div>
@@ -82,9 +82,9 @@
                                                     <label class="block margin-bottom--1" for="start-month">Month</label>
                                                     <div class="select-alt">
                                                         <select class="select width-sm--10 width-md--10 width-lg--10" name="start-month" id="start-month">
-                                                        {{ range $.Data.Months }}
+                                                            {{ range $.Data.Months }}
                                                             <option value="{{.}}" {{if eq $.Data.CheckedRadio "range"}}{{if eq . $.Data.SelectedStartMonth}}selected{{end}}{{end}}>{{.}}</option>
-                                                        {{ end }}
+                                                            {{ end }}
                                                         </select>
                                                     </div>
                                                 </div>
@@ -92,9 +92,9 @@
                                                     <label class="block margin-bottom--1" for="start-year">Year</label>
                                                     <div class="select-alt">
                                                         <select class="select width-sm--10 width-md--10 width-lg--10" name="start-year" id="start-year">
-                                                        {{ range $.Data.Years }}
+                                                            {{ range $.Data.Years }}
                                                             <option value="{{.}}" {{if eq $.Data.CheckedRadio "range"}}{{if eq . $.Data.SelectedStartYear}}selected{{end}}{{end}}>{{.}}</option>
-                                                        {{ end }}
+                                                            {{ end }}
                                                         </select>
                                                     </div>
                                                 </div>
@@ -107,9 +107,9 @@
                                                     <label class="block margin-bottom--1" for="end-month">Month</label>
                                                     <div class="select-alt">
                                                         <select class="select width-sm--10 width-md--10 width-lg--10" name="end-month" id="end-month">
-                                                        {{ range $.Data.Months }}
+                                                            {{ range $.Data.Months }}
                                                             <option value="{{.}}" {{if eq $.Data.CheckedRadio "range"}}{{if eq . $.Data.SelectedEndMonth}}selected{{end}}{{end}}>{{.}}</option>
-                                                        {{ end }}
+                                                            {{ end }}
                                                         </select>
                                                     </div>
                                                 </div>
@@ -117,9 +117,9 @@
                                                     <label class="block margin-bottom--1" for="end-year">Year</label>
                                                     <div class="select-alt">
                                                         <select class="select width-sm--10 width-md--10 width-lg--10" name="end-year" id="end-year">
-                                                        {{ range $.Data.Years }}
+                                                            {{ range $.Data.Years }}
                                                             <option value="{{.}}" {{if eq $.Data.CheckedRadio "range"}}{{if eq . $.Data.SelectedEndYear}}selected{{end}}{{end}}>{{.}}</option>
-                                                        {{ end }}
+                                                            {{ end }}
                                                         </select>
                                                     </div>
                                                 </div>
@@ -129,45 +129,61 @@
                                 </div>
                                 <div class="multiple-choice">
                                     <input id="time-selection-list" type="radio" name="time-selection" class="multiple-choice__input" value="list" {{if eq .Data.CheckedRadio "list"}}checked{{end}}>
-                                    <label for="time-selection-list" class="multiple-choice__label">Add {{.Data.Type}}s from list</label>
-                                        <div id="multiple-choice-content-list" class="multiple-choice__content padding-top--2 col-wrap">
-                                            <div class="col col--md-20 col--lg-15 margin-left-md--1">
-                                                <div class="margin-left--1">
-                                                    <fieldset>
-                                                        <legend class="visuallyhidden"> {{.Data.Type}} filter options</legend>
-                                                            <div class="checkbox-group">
-                                                                <div id="checkbox-header" class="checkbox margin-bottom--2">
-                                                                    <input class="btn btn--link underline-link add-all" type="submit" value="Add all" id="add-all" name="add-all" aria-label="Include data from all available months" />
-                                                                    &nbsp;&nbsp;<input class="btn btn--link underline-link remove-all js-hidden" type="submit" value="Remove all" id="remove-all" name="remove-all" aria-label="Remove all selected months" />
-                                                                </div>
-                                                                {{ range $i, $v := .Data.Values }}
-                                                                <div class="checkbox">
-                                                                    <input type="checkbox" class="checkbox__input {{if $v.IsSelected}} checked{{end}}" id="id-{{$v.Month}}-{{$v.Year}}" name="{{$v.Option}}" value="{{$v.Month}} {{$v.Year}}" {{if $v.IsSelected}}checked{{end}}>
-                                                                    <label class="checkbox__label" for="id-{{$v.Month}}-{{$v.Year}}">
-                                                                        {{$v.Month}} {{$v.Year}} {{if eq $i 0}} (latest) {{end}}
-                                                                    </label>
-                                                                </div>
-                                                                {{end}}
-                                                            </div>
-                                                    </fieldset>
+                                    <label for="time-selection-list" class="multiple-choice__label">Select the month, or months you want to download</label>
+                                    <div id="multiple-choice-content-list" class="multiple-choice__content padding-top--2 col-wrap">
+                                        <div class="col col--md-20 col--lg-15 margin-left-md--1">
+                                            <div class="margin-left--1">
+                                                <fieldset>
+                                                    <legend class="visuallyhidden"> {{.Data.Type}} filter options</legend>
+                                                    <div class="checkbox-group margin-bottom--4">
+                                                        {{ range $i, $v := .Data.GroupedSelection.Months }}
+                                                        <div class="checkbox">
+                                                            <input type="checkbox" class="checkbox__input {{if $v.IsSelected}} checked{{end}}" id="id-{{$v.Name}}" name="months" value="{{$v.Name}}" {{if $v.IsSelected}}checked{{end}}>
+                                                            <label class="checkbox__label" for="id-{{$v.Name}}">
+                                                                {{$v.Name}}
+                                                            </label>
+                                                        </div>
+                                                        {{end}}
+                                                    </div>
+                                                    <div id="grouped-range" class="col col--lg-17 col--md-17 margin-bottom--3">
+                                                        <label class="block margin-bottom--1" for="start-year-grouped">Select the year to start filtering from</label>
+                                                        <div class="select-alt">
+                                                            <select class="select width-sm--10 width-md--10 width-lg--10" name="start-year-grouped" id="start-year-grouped">
+                                                                {{ range $.Data.Years }}
+                                                                <option value="{{.}}" {{if eq $.Data.CheckedRadio "list"}}{{if eq . $.Data.GroupedSelection.YearStart}}selected{{end}}{{end}}>{{.}}</option>
+                                                                {{ end }}
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col col--lg-17 col--md-17 margin-bottom--0">
+                                                    <label class="block margin-bottom--1" for="end-year-grouped">Select the year to end filtering at</label>
+                                                    <div class="select-alt">
+                                                        <select class="select width-sm--10 width-md--10 width-lg--10" name="end-year-grouped" id="end-year-grouped">
+                                                            {{ range $.Data.Years }}
+                                                            <option value="{{.}}" {{if eq $.Data.CheckedRadio "list"}}{{if eq . $.Data.GroupedSelection.YearEnd}}selected{{end}}{{end}}>{{.}}</option>
+                                                            {{ end }}
+                                                        </select>
+                                                    </div>
                                                 </div>
+                                                </fieldset>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
-                            </fieldset>
-                            <div id="add-all-save-and-return" class="col col--md-25 col--lg-15 margin-top--1 margin-left--10 js-hidden">
-                                <div class="margin-bottom--6 hide--md-only hide--sm">
-                                    <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap full-width" value="Save and return">
-                                </div>
-                            </div>
-                            <div id="save-and-return-container" class="col--md-20 col--lg-20 width-sm--20">
-                                <input name="save-and-return" id="time-save-and-return" class="btn btn--primary btn--thick btn--big btn--focus btn--wide font-weight-700 font-size--17 margin-right--2" type="submit" value="Save and return" />
+                        </div>
+                        </fieldset>
+                        <div id="add-all-save-and-return" class="col col--md-25 col--lg-15 margin-top--1 margin-left--10 js-hidden">
+                            <div class="margin-bottom--6 hide--md-only hide--sm">
+                                <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap full-width" value="Save and return">
                             </div>
                         </div>
+                        <div id="save-and-return-container" class="col--md-20 col--lg-20 width-sm--20">
+                            <input name="save-and-return" id="time-save-and-return" class="btn btn--primary btn--thick btn--big btn--focus btn--wide font-weight-700 font-size--17 margin-right--2" type="submit" value="Save and return" />
+                        </div>
                     </div>
-                </form>
             </div>
+            </form>
         </div>
     </div>
+</div>
 </div>

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/5d7bec8"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/523beb3"
 	}
 	return cfg, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/ONSdigital/dp-frontend-models v1.7.0
+	github.com/ONSdigital/dp-frontend-models v1.8.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/go-ns v0.0.0-20200902154605-290c8b5ba5eb
 	github.com/ONSdigital/log.go v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/ONSdigital/dp-frontend-models v1.6.0 h1:hWdFrm6bKlK0AD3HeY2CG2Idjzbfv
 github.com/ONSdigital/dp-frontend-models v1.6.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-frontend-models v1.7.0 h1:AZpriGMwNCA1mUt1ZpbPN6jo57wVXcG3E0DAoO6R6uQ=
 github.com/ONSdigital/dp-frontend-models v1.7.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
+github.com/ONSdigital/dp-frontend-models v1.8.0 h1:GnSO18hvjNGDblxNIEATXhGz32DO+H9eshkCAcbjFQY=
+github.com/ONSdigital/dp-frontend-models v1.8.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e h1:H2KVzsFp5oTbqjPXDlTHOB/LvYy2I6Mc8eSTLrmZkXs=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.2 h1:N8SzpYzdixVgJS9NMzTBA2RZ2bi3Am1wE5F8ROEpTYw=


### PR DESCRIPTION
### What

Not ready to merge until: https://github.com/ONSdigital/sixteens/pull/245 is merged into develop (need to update this PR with the new lib update then)

This has all been PRed before and approved: https://github.com/ONSdigital/dp-frontend-renderer/pull/517

This is a reimplementation of the revert: https://github.com/ONSdigital/dp-frontend-renderer/pull/517 with two additional lines added which are done and can be seen in this commit: https://github.com/ONSdigital/dp-frontend-renderer/commit/4ceb009ab914f9e5f15bd6ba619e7978be4ec112

Most of this code was reverted as some additional JS was needed. To prevent holding up other work this was reverted in the short term but is now ready to go back in and progress. 

### How to review

Can be tested in conjunction with:
- https://github.com/ONSdigital/dp-frontend-filter-dataset-controller/pull/235
- https://github.com/ONSdigital/sixteens/pull/245

1. Go to a CMD dataset like a timeseires that has Time as a dimension (nearly all do if not all at the moment)
2. Test all options work
3. Try and break the fourth option

### Who can review

Anyone except me