### PR TITLE
feature/graceful-degradation-homepage

### DIFF
--- a/assets/locales/active.en.toml
+++ b/assets/locales/active.en.toml
@@ -575,8 +575,8 @@ description = "We are currently experiencing issues displaying this data."
 one = "We are currently experiencing issues displaying this data."
 
 [RefreshOrVisitTimeseriesTool]
-description = "Refresh the page or visit our <a href=\"/timeseriestool\">time series explorer</a> for the latest figures."
-one = "Refresh the page or visit our <a href=\"/timeseriestool\">time series explorer</a> for the latest figures."
+description = "Refresh the page or visit our <a href=\"/timeseriestool\" class=\"tile__link\">time series explorer</a> for the latest figures."
+one = "Refresh the page or visit our <a href=\"/timeseriestool\" class=\"tile__link\">time series explorer</a> for the latest figures."
 
 # Around The ONS - Homepage Section
 [AroundTheONS]

--- a/assets/templates/homepage.tmpl
+++ b/assets/templates/homepage.tmpl
@@ -10,9 +10,11 @@
     {{ template "homepage/promos" . }}
     <div class="wrapper background-gallery">
         <div class="tiles">
-            <div class="tiles__block tiles__block-no-mar-bottom">
-                {{ template "homepage/in-focus" . }}
-            </div>
+            {{ if .Data.HasFeaturedContent }}
+                <div class="tiles__block tiles__block-no-mar-bottom">
+                    {{ template "homepage/in-focus" . }}
+                </div>
+            {{ end }}
             <div class="tiles__block tiles__block-no-mar-bottom">
                 {{ template "homepage/around-the-ons" . }}
             </div>

--- a/assets/templates/homepage/latest-releases.tmpl
+++ b/assets/templates/homepage/latest-releases.tmpl
@@ -9,8 +9,8 @@
     </header>
     <div class="tile__content-container--space-between">
         <p class="tile__content tile__text-description margin-top--0 margin-bottom--0 font-size--18">
-        {{ localise "ReleaseCalendarTileInfo" .Language 1 }} {{ localise "ReleaseCalendarTilePublicationCount" .Language 1 }} 
-        {{ .Data.ReleaseCalendar.NumberOfReleases }} {{ localise "ReleaseCalendarTilePublicationPeriod" .Language 1 }}
+        {{ localise "ReleaseCalendarTileInfo" .Language 1 }} {{ if gt $releasesLen 0 }}{{ localise "ReleaseCalendarTilePublicationCount" .Language 1 }} 
+         {{ .Data.ReleaseCalendar.NumberOfReleases }} {{ localise "ReleaseCalendarTilePublicationPeriod" .Language 1 }} {{ end }}
         </p>
         <p class="margin-top--0 margin-bottom--0 padding-bottom--0">
             <a class="tile__link" href="/releasecalendar">{{ localise "AllReleases" .Language 1 }}</a>

--- a/assets/templates/homepage/main-figures-error.tmpl
+++ b/assets/templates/homepage/main-figures-error.tmpl
@@ -1,4 +1,4 @@
 <div>
-    <div class="font-weight-700 margin-top--2 margin-bottom--2"> {{ localise "ExperiencingIssues" .Language 1}} </div>
+    <div class="font-weight-700 margin-top--1 margin-bottom--2"> {{ localise "ExperiencingIssues" .Language 1}} </div>
     <div> {{ localise "RefreshOrVisitTimeseriesTool" .Language 1 | safeHTML }} </div>
 </div>

--- a/assets/templates/homepage/main-figures-none.tmpl
+++ b/assets/templates/homepage/main-figures-none.tmpl
@@ -1,5 +1,5 @@
-<div class="col col--lg-29 col--md-29">
-    <article class="tile tile__content margin-top-lg--2 margin-top-md--2 margin-left-md--1 margin-left-lg--0 height-lg--31">
+<div class="col col--lg-29 margin-left-md--0">
+    <article class="tile tile__content margin-top-lg--2 margin-top-md--2 margin-left-md--0 margin-left-lg--0 height-lg--31">
         <div class="tile__text-description font-weight-700 margin-top--2 margin-bottom--2"> {{ localise "ExperiencingIssues" .Language 1}} </div>
         <div class="tile__text-description"> {{ localise "RefreshOrVisitTimeseriesTool" .Language 1 | safeHTML }} </div>
     </article>

--- a/assets/templates/homepage/main-figures-none.tmpl
+++ b/assets/templates/homepage/main-figures-none.tmpl
@@ -1,0 +1,6 @@
+<div class="col col--lg-29 col--md-29">
+    <article class="tile tile__content margin-top-lg--2 margin-top-md--2 margin-left-md--1 margin-left-lg--0 height-lg--31">
+        <div class="tile__text-description font-weight-700 margin-top--2 margin-bottom--2"> {{ localise "ExperiencingIssues" .Language 1}} </div>
+        <div class="tile__text-description"> {{ localise "RefreshOrVisitTimeseriesTool" .Language 1 | safeHTML }} </div>
+    </article>
+</div>

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -129,7 +129,7 @@
         <div class="col--md-18">
             <article class="tile margin-left--1">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment</span></h2></header>
-                <section class="col col--md-15">
+                <section class="col col--md-15 height-md--42">
                     <div class="margin-top--2 tile__subheading">Employment rate</div>
                     {{ if $EmploymentRate.Figure }}
                         <div class="margin-top-md--2">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
@@ -151,7 +151,7 @@
                     {{ end }}
                 </section>
                 <div class="col tile__split-bar print--hide width-md--14 margin-left-md--0 margin-top-md--3"></div>
-                <section class="col col--md-15">
+                <section class="col col--md-15 height-md--42">
                     <div class="margin-top--1 tile__subheading">Unemployment rate</div>
                     {{ if $UnemploymentRate.Figure }}
                         <div class="margin-top-md--2">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $UnemploymentRate.Date}})</div>

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -14,6 +14,7 @@
             <a href="https://www.ons.gov.uk/timeseriestool" class="tile__link">From our time series explorer</a>
         </span>
     </header>
+    {{ if .Data.HasMainFigures }}
     <!--desktop-->
     <div class="hide--sm hide--md-only">
         <div class="flex stretch">
@@ -347,5 +348,8 @@
     <button class="col btn btn--full-width btn--primary btn--focus tile__button hide--md hide--lg nojs--hide js-main-feature-compress-button"
             type="button">Show fewer ...
     </button>
+    {{ else }}
+        {{template "homepage/main-figures-none" .}}
+    {{ end }}
 </section>
 

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -20,7 +20,7 @@
         <div class="flex stretch">
             <article class="col--lg-29 tile margin-right--1">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment</span></h2></header>
-                <section class="inline-block col--lg-12 margin-right--1">
+                <section class="inline-block col--lg-12 margin-right--1 text-align-top">
                     <div class="margin-top--1 tile__subheading">Employment rate</div>
                     {{ if $EmploymentRate.Figure }}
                         <div class="margin-top-md--2 margin-top-lg--1 height-lg--11">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
@@ -41,7 +41,7 @@
                         {{ template "homepage/main-figures-error" . }}
                     {{ end }}
                 </section>
-                <section class="inline-block margin-left--1 col--lg-12">
+                <section class="inline-block margin-left--1 col--lg-12 text-align-top">
                     <div class="margin-top--1 tile__subheading">Unemployment rate</div>
                     {{ if $UnemploymentRate.Figure }}
                         <div class="margin-top-md--2 margin-top-lg--1 height-lg--11">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $UnemploymentRate.Date}})</div>
@@ -154,7 +154,7 @@
                 <section class="col col--md-15">
                     <div class="margin-top--1 tile__subheading">Unemployment rate</div>
                     {{ if $UnemploymentRate.Figure }}
-                        <div class="margin-top-md--2">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
+                        <div class="margin-top-md--2">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $UnemploymentRate.Date}})</div>
                         <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
                         <p class="tile__trend">
                             <span class="tile__trend__icon">
@@ -324,7 +324,7 @@
                 <div class="col">
                     <div class="margin-top--1 tile__subheading"><b>Unemployment rate</b></div>
                     {{ if $UnemploymentRate.Figure }}
-                        <div class="">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date }})</div>
+                        <div class="">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $UnemploymentRate.Date }})</div>
                         <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
                         <p class="tile__trend">
                             <span class="tile__trend__icon">

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/ONSdigital/dp-frontend-models v1.8.0
+	github.com/ONSdigital/dp-frontend-models v1.9.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/go-ns v0.0.0-20200902154605-290c8b5ba5eb
 	github.com/ONSdigital/log.go v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/ONSdigital/dp-frontend-models v1.7.0 h1:AZpriGMwNCA1mUt1ZpbPN6jo57wVX
 github.com/ONSdigital/dp-frontend-models v1.7.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-frontend-models v1.8.0 h1:GnSO18hvjNGDblxNIEATXhGz32DO+H9eshkCAcbjFQY=
 github.com/ONSdigital/dp-frontend-models v1.8.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
+github.com/ONSdigital/dp-frontend-models v1.9.0 h1:Llgiapaec6VadA+bPdiMSEWykdVDTvDkbbC50ja68/4=
+github.com/ONSdigital/dp-frontend-models v1.9.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e h1:H2KVzsFp5oTbqjPXDlTHOB/LvYy2I6Mc8eSTLrmZkXs=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.2 h1:N8SzpYzdixVgJS9NMzTBA2RZ2bi3Am1wE5F8ROEpTYw=


### PR DESCRIPTION
### What

- Implemented graceful degradation states as per Sketch copies
- Created new partial for rendering when no main figures successfully loaded

### How to review

- Check that the changes make sense
- You can review in conjunction with the [frontend homepage controller PR](https://github.com/ONSdigital/dp-frontend-homepage-controller/pull/46) (follow graceful degradation steps below)

**Graceful degradation states for checking locally**
1. Comment out a main figure URI in `homepage.go` in dp-frontend-homepage-controller: that corresponding tile in the homepage should show a failed to load state
2. Comment out all main figure URIs in `homepage.go` in dp-frontend-homepage-controller: all the tiles are replaced by a single tile, aligned to the latest releases tile, that shares the same fail state message
3. Contrive a way to not have any latest releases in the last 7 days (not sure how best to do this locally). The second sentence in the latest releases tile should no longer be present (i.e., "we have published _n_ releases...")
4. Remove any featured content you have in your homepage `data.json` in you Zebedee content dir. The In Focus section should then not render at all

### Who can review

Anyone