### PR TITLE
Keywords meta tag removed

### DIFF
--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -6,7 +6,6 @@
       {{ else if .Error -}}{{if .Error.Title }}{{ .Error.Title }}{{- end }}
       {{- end}} - {{ localise "OfficeForNationalStatistics" .Language 1 }}</title>
     {{if eq .Metadata.Title "Home"}}<meta name="description" content="{{ localise "HomepageDescription" .Language 1 }}">{{else}}<meta name="description" content="{{ .Metadata.Description}}">{{end}}
-    <meta name="keywords" content="{{range .Metadata.Keywords}} {{- .}}, {{end}}">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta charset="utf-8"/>
     <meta content="width=device-width,initial-scale=1.0,user-scalable=1" name="viewport">


### PR DESCRIPTION
### What

- Removed meta tag on main.tmpl
- This is not used by search engines for positive reasons anymore
- Can be used by some engine to help identify spam (potentially bing)
- Removed to avoid us accidentally getting higher spam ratings and having unnecessary bloat

The following used to be present: (note this is on homepage, other pages have keywords and are not just empty)
![Screenshot 2020-10-20 at 15 20 42](https://user-images.githubusercontent.com/47502916/96599521-edb8f900-12e7-11eb-996e-47cc93b2b1d8.png)

But now it isn't:
![Screenshot 2020-10-20 at 15 58 28](https://user-images.githubusercontent.com/47502916/96605067-ae8da680-12ed-11eb-8e3e-e78ba778541d.png)


Note: model data still has keywords stored as this can be used in Structured Data to improve SEO

### How to review

Open the DOM on a number of pages (inspect elements). Go to the <head> tag and inside its contents check for <meta> tags. Ensure that none have the property name="keywords".

Pages should all still load and function as they did before



### Who can review

Anyone except me