### PR TITLE
Update version of sixteens to v1.4.5

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/901c5f7"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/a40165a"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What

Version of sixteens updated to version 1.4.5 which includes:
- Feedback form focus highlighting is now in line with the rest of the website
- Feedback form error highlighting is now in line with the rest of the website
- Uncomputable size in form-helper fixed
- Filter pages age and time now have a new accessibility feature of reading out errors on form input

### How to review

Check that this is the correct latest release of sixteens
Check that the version of sixteens has indeed been updated

### Who can review

Anyone except me
