### PR TITLE
Release 1.31.0

### DIFF
--- a/assets/locales/active.cy.toml
+++ b/assets/locales/active.cy.toml
@@ -667,3 +667,82 @@ one = "other releases this week"
 [AllReleases]
 description = "View all of our releases by date"
 one = "View all of our releases by date"
+
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+# Feedback Form/Form Page
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[FeedbackTitle]
+description = "{{.Metadata.Title}}"
+one = "{{.arg0}}"
+
+[FeedbackDesc]
+descriptions = "You can use the form below to ask a question, report a problem or suggest an improvement we can make to ONS.GOV.UK"
+one = "You can use the form below to ask a question, report a problem or suggest an improvement to the ONS.GOV.UK team."
+
+[FeedbackTitleWhat]
+description = "What's it to do with?"
+one = "What's it to do with?"
+
+[FeedbackWhatOptSpecificPage]
+description = "This specific page"
+one = "This specific page"
+
+[FeedbackWhatEnterURL]
+description = "Enter URL or name of the page"
+one = "Enter URL or name of the page"
+
+[FeedbackWhatOptHintSpecificPage]
+description = "{{.ServiceDescription}}"
+one = "({{.arg0}})"
+
+[FeedbackWhatOptNewService]
+description = "This new service"
+one = "This new service"
+
+[FeedbackWhatOptGeneral]
+description = "The whole <abbr title=\"Office for National Statistics\">ONS</abbr> website or general feedback"
+one = "The whole ONS website or general feedback"
+
+[FeedbackTitleEntry]
+description = "What are the details?"
+one = "What are the details?"
+
+[FeedbackHintEntry]
+description = "For example, if you were searching for something, what did you type into the search box?"
+one = "For example, if you were searching for something, what did you type into the search box?"
+
+[FeedbackAlertEntry]
+description = "Write some feedback"
+one = "Write some feedback"
+
+[FeedbackTitleReply]
+description = "Do you want a reply?"
+one = "Do you want a reply?"
+
+[FeedbackDescReply]
+description = "If you'd like us to get back to you, please add your name and email address below."
+one = "If you'd like us to get back to you, please add your name and email address below."
+
+[FeedbackTitleName]
+description = "Name (optional)"
+one = "Name (optional)"
+
+[FeedbackTitleEmail]
+description = "Email (optional)"
+one = "Email (optional)"
+
+[FeedbackReplyDisclaimer]
+description = "We'll only use this to reply to your message"
+one = "We'll only use this to reply to your message."
+
+[FeedbackAlertEmail]
+description = "This is not a valid email address, correct it or delete it"
+one = "This is not a valid email address, correct it or delete it"
+
+[FeedbackSubmit]
+description = "Send feedback"
+one = "Send feedback"
+
+[FeedbackFinished]
+description = "Your feedback will help us to improve the website. We are unable to respond to all enquiries. If your matter is urgent, please <a href=\"/aboutus/contactus\">contact us</a>.<br><br>Return to <a href=\"{{.Metadata.Description}}\">{{.Metadata.Description}}"
+one = "Your feedback will help us to improve the website. We are unable to respond to all enquiries. If your matter is urgent, please <a href=\"/aboutus/contactus\">contact us</a>.<br><br>Return to <a href=\"{{.arg0}}\">{{.arg0}}"

--- a/assets/locales/active.en.toml
+++ b/assets/locales/active.en.toml
@@ -575,8 +575,8 @@ description = "We are currently experiencing issues displaying this data."
 one = "We are currently experiencing issues displaying this data."
 
 [RefreshOrVisitTimeseriesTool]
-description = "Refresh the page or visit our <a href=\"/timeseriestool\">time series explorer</a> for the latest figures."
-one = "Refresh the page or visit our <a href=\"/timeseriestool\">time series explorer</a> for the latest figures."
+description = "Refresh the page or visit our <a href=\"/timeseriestool\" class=\"tile__link\">time series explorer</a> for the latest figures."
+one = "Refresh the page or visit our <a href=\"/timeseriestool\" class=\"tile__link\">time series explorer</a> for the latest figures."
 
 # Around The ONS - Homepage Section
 [AroundTheONS]
@@ -642,3 +642,82 @@ one = "other releases this week"
 [AllReleases]
 description = "View all of our releases by date"
 one = "View all of our releases by date"
+
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+# Feedback Form/Form Page
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+[FeedbackTitle]
+description = "{{.Metadata.Title}}"
+one = "{{.arg0}}"
+
+[FeedbackDesc]
+descriptions = "You can use the form below to ask a question, report a problem or suggest an improvement we can make to ONS.GOV.UK"
+one = "You can use the form below to ask a question, report a problem or suggest an improvement to the ONS.GOV.UK team."
+
+[FeedbackTitleWhat]
+description = "What's it to do with?"
+one = "What's it to do with?"
+
+[FeedbackWhatOptSpecificPage]
+description = "This specific page"
+one = "This specific page"
+
+[FeedbackWhatEnterURL]
+description = "Enter URL or name of the page"
+one = "Enter URL or name of the page"
+
+[FeedbackWhatOptHintSpecificPage]
+description = "{{.ServiceDescription}}"
+one = "({{.arg0}})"
+
+[FeedbackWhatOptNewService]
+description = "This new service"
+one = "This new service"
+
+[FeedbackWhatOptGeneral]
+description = "The whole <abbr title=\"Office for National Statistics\">ONS</abbr> website or general feedback"
+one = "The whole ONS website or general feedback"
+
+[FeedbackTitleEntry]
+description = "What are the details?"
+one = "What are the details?"
+
+[FeedbackHintEntry]
+description = "For example, if you were searching for something, what did you type into the search box?"
+one = "For example, if you were searching for something, what did you type into the search box?"
+
+[FeedbackAlertEntry]
+description = "Write some feedback"
+one = "Write some feedback"
+
+[FeedbackTitleReply]
+description = "Do you want a reply?"
+one = "Do you want a reply?"
+
+[FeedbackDescReply]
+description = "If you'd like us to get back to you, please add your name and email address below."
+one = "If you'd like us to get back to you, please add your name and email address below."
+
+[FeedbackTitleName]
+description = "Name (optional)"
+one = "Name (optional)"
+
+[FeedbackTitleEmail]
+description = "Email (optional)"
+one = "Email (optional)"
+
+[FeedbackReplyDisclaimer]
+description = "We'll only use this to reply to your message"
+one = "We'll only use this to reply to your message."
+
+[FeedbackAlertEmail]
+description = "This is not a valid email address, correct it or delete it"
+one = "This is not a valid email address, correct it or delete it"
+
+[FeedbackSubmit]
+description = "Send feedback"
+one = "Send feedback"
+
+[FeedbackFinished]
+description = "Your feedback will help us to improve the website. We are unable to respond to all enquiries. If your matter is urgent, please <a href=\"/aboutus/contactus\">contact us</a>.<br><br>Return to <a href=\"{{.Metadata.Description}}\">{{.Metadata.Description}}"
+one = "Your feedback will help us to improve the website. We are unable to respond to all enquiries. If your matter is urgent, please <a href=\"/aboutus/contactus\">contact us</a>.<br><br>Return to <a href=\"{{.arg0}}\">{{.arg0}}"

--- a/assets/templates/dataset-filter/time.tmpl
+++ b/assets/templates/dataset-filter/time.tmpl
@@ -41,6 +41,8 @@
                                     <input type="hidden" name="latest-option" value="{{.Data.LatestTime.Option}}">
                                     <input type="hidden" name="latest-month" id="lastest-month" value="{{.Data.LatestTime.Month}}">
                                     <input type="hidden" name="latest-year" id="latest-year" value="{{.Data.LatestTime.Year}}">
+                                    <input type="hidden" name="first-year" id="first-year" value="{{.Data.FirstTime.Year}}">
+                                    <input type="hidden" name="first-month" id="first-month" value="{{.Data.FirstTime.Month}}">
                                 </div>
                                 <div class="multiple-choice">
                                     <input id="time-selection-single" type="radio" class="multiple-choice__input" name="time-selection" value="single" {{if eq .Data.CheckedRadio "single"}}checked{{end}}>
@@ -52,9 +54,9 @@
                                                     <label class="block margin-bottom--1" for="month-single">Month</label>
                                                     <div class="select-alt">
                                                         <select class="select width-sm--10 width-md--10 width-lg--10" name="month-single" id="month-single">
-                                                        {{ range $.Data.Months }}
+                                                            {{ range $.Data.Months }}
                                                             <option value="{{.}}" {{if eq $.Data.CheckedRadio "single"}}{{if eq . $.Data.SelectedStartMonth}}selected{{end}}{{end}}>{{.}}</option>
-                                                        {{ end }}
+                                                            {{ end }}
                                                         </select>
                                                     </div>
                                                 </div>
@@ -62,9 +64,9 @@
                                                     <label class="block margin-bottom--1" for="year-single">Year</label>
                                                     <div class="select-alt">
                                                         <select class="select width-sm--10 width-md--10 width-lg--10" name="year-single" id="year-single">
-                                                        {{ range $.Data.Years }}
+                                                            {{ range $.Data.Years }}
                                                             <option value="{{.}}" {{if eq $.Data.CheckedRadio "single"}}{{if eq . $.Data.SelectedStartYear}}selected{{end}}{{end}}>{{.}}</option>
-                                                        {{ end }}
+                                                            {{ end }}
                                                         </select>
                                                     </div>
                                                 </div>
@@ -82,9 +84,9 @@
                                                     <label class="block margin-bottom--1" for="start-month">Month</label>
                                                     <div class="select-alt">
                                                         <select class="select width-sm--10 width-md--10 width-lg--10" name="start-month" id="start-month">
-                                                        {{ range $.Data.Months }}
+                                                            {{ range $.Data.Months }}
                                                             <option value="{{.}}" {{if eq $.Data.CheckedRadio "range"}}{{if eq . $.Data.SelectedStartMonth}}selected{{end}}{{end}}>{{.}}</option>
-                                                        {{ end }}
+                                                            {{ end }}
                                                         </select>
                                                     </div>
                                                 </div>
@@ -92,9 +94,9 @@
                                                     <label class="block margin-bottom--1" for="start-year">Year</label>
                                                     <div class="select-alt">
                                                         <select class="select width-sm--10 width-md--10 width-lg--10" name="start-year" id="start-year">
-                                                        {{ range $.Data.Years }}
+                                                            {{ range $.Data.Years }}
                                                             <option value="{{.}}" {{if eq $.Data.CheckedRadio "range"}}{{if eq . $.Data.SelectedStartYear}}selected{{end}}{{end}}>{{.}}</option>
-                                                        {{ end }}
+                                                            {{ end }}
                                                         </select>
                                                     </div>
                                                 </div>
@@ -107,9 +109,9 @@
                                                     <label class="block margin-bottom--1" for="end-month">Month</label>
                                                     <div class="select-alt">
                                                         <select class="select width-sm--10 width-md--10 width-lg--10" name="end-month" id="end-month">
-                                                        {{ range $.Data.Months }}
+                                                            {{ range $.Data.Months }}
                                                             <option value="{{.}}" {{if eq $.Data.CheckedRadio "range"}}{{if eq . $.Data.SelectedEndMonth}}selected{{end}}{{end}}>{{.}}</option>
-                                                        {{ end }}
+                                                            {{ end }}
                                                         </select>
                                                     </div>
                                                 </div>
@@ -117,9 +119,9 @@
                                                     <label class="block margin-bottom--1" for="end-year">Year</label>
                                                     <div class="select-alt">
                                                         <select class="select width-sm--10 width-md--10 width-lg--10" name="end-year" id="end-year">
-                                                        {{ range $.Data.Years }}
+                                                            {{ range $.Data.Years }}
                                                             <option value="{{.}}" {{if eq $.Data.CheckedRadio "range"}}{{if eq . $.Data.SelectedEndYear}}selected{{end}}{{end}}>{{.}}</option>
-                                                        {{ end }}
+                                                            {{ end }}
                                                         </select>
                                                     </div>
                                                 </div>
@@ -129,45 +131,61 @@
                                 </div>
                                 <div class="multiple-choice">
                                     <input id="time-selection-list" type="radio" name="time-selection" class="multiple-choice__input" value="list" {{if eq .Data.CheckedRadio "list"}}checked{{end}}>
-                                    <label for="time-selection-list" class="multiple-choice__label">Add {{.Data.Type}}s from list</label>
-                                        <div id="multiple-choice-content-list" class="multiple-choice__content padding-top--2 col-wrap">
-                                            <div class="col col--md-20 col--lg-15 margin-left-md--1">
-                                                <div class="margin-left--1">
-                                                    <fieldset>
-                                                        <legend class="visuallyhidden"> {{.Data.Type}} filter options</legend>
-                                                            <div class="checkbox-group">
-                                                                <div id="checkbox-header" class="checkbox margin-bottom--2">
-                                                                    <input class="btn btn--link underline-link add-all" type="submit" value="Add all" id="add-all" name="add-all" aria-label="Include data from all available months" />
-                                                                    &nbsp;&nbsp;<input class="btn btn--link underline-link remove-all js-hidden" type="submit" value="Remove all" id="remove-all" name="remove-all" aria-label="Remove all selected months" />
-                                                                </div>
-                                                                {{ range $i, $v := .Data.Values }}
-                                                                <div class="checkbox">
-                                                                    <input type="checkbox" class="checkbox__input {{if $v.IsSelected}} checked{{end}}" id="id-{{$v.Month}}-{{$v.Year}}" name="{{$v.Option}}" value="{{$v.Month}} {{$v.Year}}" {{if $v.IsSelected}}checked{{end}}>
-                                                                    <label class="checkbox__label" for="id-{{$v.Month}}-{{$v.Year}}">
-                                                                        {{$v.Month}} {{$v.Year}} {{if eq $i 0}} (latest) {{end}}
-                                                                    </label>
-                                                                </div>
-                                                                {{end}}
-                                                            </div>
-                                                    </fieldset>
+                                    <label for="time-selection-list" class="multiple-choice__label">Select the month, or months you want to download</label>
+                                    <div id="multiple-choice-content-list" class="multiple-choice__content padding-top--2 col-wrap">
+                                        <div class="col col--md-20 col--lg-15 margin-left-md--1">
+                                            <div class="margin-left--1">
+                                                <fieldset>
+                                                    <legend class="visuallyhidden"> {{.Data.Type}} filter options</legend>
+                                                    <div class="checkbox-group margin-bottom--4">
+                                                        {{ range $i, $v := .Data.GroupedSelection.Months }}
+                                                        <div class="checkbox">
+                                                            <input type="checkbox" class="checkbox__input {{if eq $.Data.CheckedRadio "list"}}{{if $v.IsSelected}} checked{{end}}{{end}}" id="id-{{$v.Name}}" name="months" value="{{$v.Name}}" {{if eq $.Data.CheckedRadio "list"}}{{if $v.IsSelected}}checked{{end}}{{end}}>
+                                                            <label class="checkbox__label" for="id-{{$v.Name}}">
+                                                                {{$v.Name}}
+                                                            </label>
+                                                        </div>
+                                                        {{end}}
+                                                    </div>
+                                                    <div id="grouped-range" class="col col--lg-17 col--md-17 margin-bottom--3">
+                                                        <label class="block margin-bottom--1" for="start-year-grouped">Select the year to start filtering from</label>
+                                                        <div class="select-alt">
+                                                            <select class="select width-sm--10 width-md--10 width-lg--10" name="start-year-grouped" id="start-year-grouped">
+                                                                {{ range $.Data.Years }}
+                                                                <option value="{{.}}" {{if eq $.Data.CheckedRadio "list"}}{{if eq . $.Data.GroupedSelection.YearStart}}selected{{end}}{{end}}>{{.}}</option>
+                                                                {{ end }}
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col col--lg-17 col--md-17 margin-bottom--0">
+                                                    <label class="block margin-bottom--1" for="end-year-grouped">Select the year to end filtering at</label>
+                                                    <div class="select-alt">
+                                                        <select class="select width-sm--10 width-md--10 width-lg--10" name="end-year-grouped" id="end-year-grouped">
+                                                            {{ range $.Data.Years }}
+                                                            <option value="{{.}}" {{if eq $.Data.CheckedRadio "list"}}{{if eq . $.Data.GroupedSelection.YearEnd}}selected{{end}}{{end}}>{{.}}</option>
+                                                            {{ end }}
+                                                        </select>
+                                                    </div>
                                                 </div>
+                                                </fieldset>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
-                            </fieldset>
-                            <div id="add-all-save-and-return" class="col col--md-25 col--lg-15 margin-top--1 margin-left--10 js-hidden">
-                                <div class="margin-bottom--6 hide--md-only hide--sm">
-                                    <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap full-width" value="Save and return">
-                                </div>
-                            </div>
-                            <div id="save-and-return-container" class="col--md-20 col--lg-20 width-sm--20">
-                                <input name="save-and-return" id="time-save-and-return" class="btn btn--primary btn--thick btn--big btn--focus btn--wide font-weight-700 font-size--17 margin-right--2" type="submit" value="Save and return" />
+                        </div>
+                        </fieldset>
+                        <div id="add-all-save-and-return" class="col col--md-25 col--lg-15 margin-top--1 margin-left--10 js-hidden">
+                            <div class="margin-bottom--6 hide--md-only hide--sm">
+                                <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap full-width" value="Save and return">
                             </div>
                         </div>
+                        <div id="save-and-return-container" class="col--md-20 col--lg-20 width-sm--20">
+                            <input name="save-and-return" id="time-save-and-return" class="btn btn--primary btn--thick btn--big btn--focus btn--wide font-weight-700 font-size--17 margin-right--2" type="submit" value="Save and return" />
+                        </div>
                     </div>
-                </form>
             </div>
+            </form>
         </div>
     </div>
+</div>
 </div>

--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -74,7 +74,7 @@
                 <ul class="list--neutral">
                 {{range $i, $download := $v.Downloads}}
                 {{if gt (len $download.Size) 0}}{{if gt (len $download.Size) 0}}<li class="padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix"><span class="inline-block padding-top--2">{{if eq $download.Extension "txt"}}Supporting information{{else}}Complete dataset (<span class="uppercase">{{$download.Extension}}</span> format){{end}}</span>
-                  <div class="width--12 inline-block float-right text-right"><a id="{{$download.Extension}}-download"                                     data-gtm-download-file="{{$download.URI}}"
+                  <div class="width--12 inline-block float-right float-el--left-sm text-left--sm"><a id="{{$download.Extension}}-download"                                     data-gtm-download-file="{{$download.URI}}"
                   data-gtm-download-type="{{$download.Extension}}" class="btn btn--primary margin-top--1 margin-bottom--1 margin-right--half width--11" href="{{$download.URI}}"><strong>{{$download.Extension}}</strong> ({{humanSize $download.Size}})</a></div></li>{{end}}{{end}}
                 {{end}}
                 </ul>

--- a/assets/templates/feedback.tmpl
+++ b/assets/templates/feedback.tmpl
@@ -1,10 +1,11 @@
+{{$Language := .Language}}
 <div class="page-intro background--gallery">
     <div class="wrapper">
         <div class="col-wrap">
             <div class="col margin-top--1">
                 {{ template "partials/breadcrumb" . }}
                 <h1 class="page-intro__title margin-bottom--4">
-                    {{.Metadata.Title}}
+                    <strong>{{ localise "FeedbackTitle" $Language 1 $.Metadata.Title }}</strong>
                 </h1>
             </div>
         </div>
@@ -15,77 +16,84 @@
         <div class="col col--lg-two-thirds col--md-two-thirds">
             {{if eq .Metadata.Title "Feedback"}}
             <div id="feedback-description">
-                <p class="font-size--16">You can use the form below to ask a question, report a problem or suggest an improvement we can make to ONS.GOV.UK</p>
+                <p class="font-size--18 margin-top--5 margin-bottom--0">{{ localise "FeedbackDesc" $Language 1}}</p>
             </div>
             <div class="margin--top-4">
                 <form id="feedback-form-container" action="/feedback" method="post">
                     <input type="hidden" name="feedback-form-type" value="page">
                     <fieldset>
-                        <legend class="font-size--16"><strong>What's it to do with?</strong></legend>
+                        <legend><h2 class="margin-bottom--4 font-size--30"><strong>{{ localise "FeedbackTitleWhat" $Language 1 }}</strong></h2></legend>
                         <div class="margin-top--2 margin-bottom--4">
+                            {{ if .PreviousURL }} 
                             <div class="multiple-choice margin-top--1">
                                 <input type="radio" class="multiple-choice__input" id="specific-page" name="type" value="A specific page" checked>
-                                <label class="multiple-choice__label font-size--16" for="specific-page">
-                                    This specific page
-                                    &nbsp; &nbsp;<span class="form-helper">(...{{.Metadata.Description}})</span>
+                                <label class="multiple-choice__label font-size--18" for="specific-page">
+                                    {{ localise "FeedbackWhatOptSpecificPage" $Language 1}}
                                     <input type="hidden" value="{{.PreviousURL}}" name="url">
                                 </label>
+                                <div class="multiple-choice__content height--5">
+                                    <div class="margin-left--1">
+                                        <div class="clearfix">
+                                            <div class="col col--md-8 col--lg-35">
+                                                <label class="font-size--18" for="page-url-field">{{ localise "FeedbackWhatEnterURL" $Language 1 }}</label>
+                                                <input type="url" id="page-url-field" value="{{.PreviousURL}}" class="form-control" name="url">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
+                            {{ end }}
+                            {{if .ServiceDescription}}
                             <div class="multiple-choice margin-top--1">
                                 <input type="radio" class="multiple-choice__input" id="new-service" name="type" value="The new service">
-                                <label class="multiple-choice__label font-size--16" for="new-service">
-                                    This new service
-                                    {{if .ServiceDescription}}
-                                        &nbsp; &nbsp;<span class="form-helper">({{.ServiceDescription}})</span>
-                                    {{end}}
+                                <label class="multiple-choice__label font-size--18" for="new-service">
+                                {{ localise "FeedbackWhatOptNewService" $Language 1  }}
+                                        &nbsp; &nbsp;<span class="form-helper">{{ localise "FeedbackWhatOptHintSpecificPage" $Language 1  $.ServiceDescription }}</span>
                                 </label>
                             </div>
+                            {{end}}
                             <div class="multiple-choice margin-top--1">
                                 <input type="radio" class="multiple-choice__input" id="whole-site" name="type" value="The whole website">
-                                <label class="multiple-choice__label font-size--16" for="whole-site">
-                                    The whole ONS website or general feedback
+                                <label class="multiple-choice__label font-size--18" for="whole-site">
+                                    {{ localise "FeedbackWhatOptGeneral" $Language 1 }}
                                 </label>
                             </div>
                         </div>
                     </fieldset>
                     <div>
-                        <label id="purpose-field-label" for="purpose-field">
-                            <strong><span class="font-size--16">What was the purpose of your visit?</span></strong>
-                        </label>
-                       {{if eq .ErrorType "purpose"}}<span class="form-error">Enter a purpose</span>{{end}}
-                        <textarea id="purpose-field" class="form-control {{if eq .ErrorType "purpose"}}form-control__error{{end}}" name="purpose" rows="2" >{{.Purpose}}</textarea>
-                    </div>
-                    <div>
                         <label id="description-field-label" for="description-field">
-                            <strong><span class="font-size--16">Your feedback</span></strong>
-                            <span class="form-hint">Report a problem, make a suggestion, ask a question or let us know what you think.</span>
+                            <h2 class="margin-top--0 margin-bottom--4 font-size--30"><strong>{{ localise "FeedbackTitleEntry" $Language 1 }}</strong></h2>
+                            <span class="font-size--18 margin-bottom--3">{{ localise "FeedbackHintEntry" $Language 1 }}</span>
                         </label>
-                        {{if eq .ErrorType "description"}}<span class="form-error">Write some feedback</span>{{end}}
+                        {{if eq .ErrorType "description"}}<span class="form-error">{{ localise "FeedbackAlertEntry" $Language 1 }}</span>{{end}}
                         <textarea id="description-field" class="form-control  {{if eq .ErrorType "description"}}form-control__error{{end}}" name="description" rows="5">{{.Feedback}}</textarea>
                     </div>
+                    <section>
+                        <fieldset id="reply-request">
+                            <legend>
+                                <h2 class="margin-top--0 margin-bottom--4 font-size--30"><strong>{{ localise "FeedbackTitleReply" $Language 1 }}</strong></h2>
+                                <p class="font-size--18 margin-bottom--3">{{ localise "FeedbackDescReply" $Language 1 }}</p>
+                            </legend>
+                            <label id="name-field-label" for="name-field">
+                                <strong><span class="font-size--18">{{ localise "FeedbackTitleName" $Language 1 }}</span></strong>
+                            </label>
+                            <input id="name-field" class="form-control" type="text" name="name"  value={{.Name}}>
+                            <label id="email-field-label" for="email-field">
+                                <strong><span class="font-size--18">{{ localise "FeedbackTitleEmail" $Language 1 }}</span></strong>
+                            </label>
+                            {{if eq .ErrorType "email"}}<span class="form-error">{{ localise "FeedbackAlertEmail" $Language 1 }}</span>{{end}}
+                            <input id="email-field" class="form-control {{if eq .ErrorType "email"}}form-control__error{{end}}" type="text" name="email"  value={{.Email}}>
+                            <div class="font-size--18 form-helper margin-bottom--4">{{ localise "FeedbackReplyDisclaimer" $Language 1 }}</div>
+                        </fieldset>
+                    </section>
                     <div>
-                        <label id="name-field-label" for="name-field">
-                            <strong><span class="font-size--16">Name (optional)</span></strong>
-                            <span class="form-hint">Include your name and email address if you would like us to get back to you.</span>
-                        </label>
-                        <input id="name-field" class="form-control" type="text" name="name"  value={{.Name}}>
-                    </div>
-                    <div>
-                        <label id="email-field-label" for="email-field">
-                            <strong><span class="font-size--16">Email (optional)</span></strong>
-                        </label>
-                        {{if eq .ErrorType "email"}}<span class="form-error">This is not a valid email address, correct it or delete it</span>{{end}}
-                        <input id="email-field" class="form-control {{if eq .ErrorType "email"}}form-control__error{{end}}" type="text" name="email"  value={{.Email}}>
-                    </div>
-                    <div>
-                        <input class="btn btn--primary font-weight-700" type="submit" value="Send feedback">
+                        <input class="btn btn--primary font-weight-700 font-size--18" type="submit" value="{{ localise "FeedbackSubmit" $Language 1 }}">
                     </div>
                 </form>
             </div>
             {{else}}
                 <div class="margin-top--4">
-                    Your feedback will help us to improve the website. We are unable to respond to all enquiries. If your matter is urgent, please <a href="/aboutus/contactus">contact us</a>.<br><br>
-                    Return to <a href="{{.Metadata.Description}}">{{.Metadata.Description}}</a>
+                    {{ localise "FeedbackFinished" $Language 1 .Metadata.Description .Metadata.Description | safeHTML }}
                 </div>
             {{end}}
         </div>

--- a/assets/templates/homepage.tmpl
+++ b/assets/templates/homepage.tmpl
@@ -10,9 +10,11 @@
     {{ template "homepage/promos" . }}
     <div class="wrapper background-gallery">
         <div class="tiles">
-            <div class="tiles__block tiles__block-no-mar-bottom">
-                {{ template "homepage/in-focus" . }}
-            </div>
+            {{ if .Data.HasFeaturedContent }}
+                <div class="tiles__block tiles__block-no-mar-bottom">
+                    {{ template "homepage/in-focus" . }}
+                </div>
+            {{ end }}
             <div class="tiles__block tiles__block-no-mar-bottom">
                 {{ template "homepage/around-the-ons" . }}
             </div>

--- a/assets/templates/homepage/in-focus.tmpl
+++ b/assets/templates/homepage/in-focus.tmpl
@@ -2,7 +2,7 @@
     <h1 class="font-size--h2 font-size--30 margin-top--1">{{ localise "InFocus" .Language 1 }}</h2>
     <div class="margin--0 flex stretch flex-wrap-wrap margin-bottom--3 content-space-between content-lg--flex-start">
     {{ range $i, $v := .Data.Featured }}
-        <section class="tile col--md-23 col--lg-14 flex-basis-sm--full {{if ne $i 3}}margin-right-lg--1{{end}}" tabindex="0">
+        <section class="tile col--md-23 col--lg-14 flex-basis-sm--full {{if (and (ne $i 3) (ne $i 7)) -}}margin-right-lg--1{{end}}" tabindex="0">
             <article class="tile__highlighted-content">
                 <div class="tile__highlighted-content-image-container">
                     <img class="tile__highlighted-content-image" src="{{if $v.ImageURL }}{{$v.ImageURL}}{{else}}https://cdn.ons.gov.uk/assets/images/featured-content-default.svg{{end}}" alt="">

--- a/assets/templates/homepage/latest-releases.tmpl
+++ b/assets/templates/homepage/latest-releases.tmpl
@@ -9,8 +9,8 @@
     </header>
     <div class="tile__content-container--space-between">
         <p class="tile__content tile__text-description margin-top--0 margin-bottom--0 font-size--18">
-        {{ localise "ReleaseCalendarTileInfo" .Language 1 }} {{ localise "ReleaseCalendarTilePublicationCount" .Language 1 }} 
-        {{ .Data.ReleaseCalendar.NumberOfReleases }} {{ localise "ReleaseCalendarTilePublicationPeriod" .Language 1 }}
+        {{ localise "ReleaseCalendarTileInfo" .Language 1 }} {{ if gt $releasesLen 0 }}{{ localise "ReleaseCalendarTilePublicationCount" .Language 1 }} 
+         {{ .Data.ReleaseCalendar.NumberOfReleases }} {{ localise "ReleaseCalendarTilePublicationPeriod" .Language 1 }} {{ end }}
         </p>
         <p class="margin-top--0 margin-bottom--0 padding-bottom--0">
             <a class="tile__link" href="/releasecalendar">{{ localise "AllReleases" .Language 1 }}</a>

--- a/assets/templates/homepage/main-figures-error.tmpl
+++ b/assets/templates/homepage/main-figures-error.tmpl
@@ -1,4 +1,4 @@
 <div>
-    <div class="font-weight-700 margin-top--2 margin-bottom--2"> {{ localise "ExperiencingIssues" .Language 1}} </div>
+    <div class="font-weight-700 margin-top--1 margin-bottom--2"> {{ localise "ExperiencingIssues" .Language 1}} </div>
     <div> {{ localise "RefreshOrVisitTimeseriesTool" .Language 1 | safeHTML }} </div>
 </div>

--- a/assets/templates/homepage/main-figures-none.tmpl
+++ b/assets/templates/homepage/main-figures-none.tmpl
@@ -1,0 +1,6 @@
+<div class="col col--lg-29 margin-left-md--0">
+    <article class="tile tile__content margin-top-lg--2 margin-top-md--2 margin-left-md--0 margin-left-lg--0 height-lg--31">
+        <div class="tile__text-description font-weight-700 margin-top--2 margin-bottom--2"> {{ localise "ExperiencingIssues" .Language 1}} </div>
+        <div class="tile__text-description"> {{ localise "RefreshOrVisitTimeseriesTool" .Language 1 | safeHTML }} </div>
+    </article>
+</div>

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -14,12 +14,13 @@
             <a href="https://www.ons.gov.uk/timeseriestool" class="tile__link">From our time series explorer</a>
         </span>
     </header>
+    {{ if .Data.HasMainFigures }}
     <!--desktop-->
     <div class="hide--sm hide--md-only">
         <div class="flex stretch">
             <article class="col--lg-29 tile margin-right--1">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment</span></h2></header>
-                <section class="inline-block col--lg-12 margin-right--1">
+                <section class="inline-block col--lg-12 margin-right--1 text-align-top">
                     <div class="margin-top--1 tile__subheading">Employment rate</div>
                     {{ if $EmploymentRate.Figure }}
                         <div class="margin-top-md--2 margin-top-lg--1 height-lg--11">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
@@ -40,7 +41,7 @@
                         {{ template "homepage/main-figures-error" . }}
                     {{ end }}
                 </section>
-                <section class="inline-block margin-left--1 col--lg-12">
+                <section class="inline-block margin-left--1 col--lg-12 text-align-top">
                     <div class="margin-top--1 tile__subheading">Unemployment rate</div>
                     {{ if $UnemploymentRate.Figure }}
                         <div class="margin-top-md--2 margin-top-lg--1 height-lg--11">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $UnemploymentRate.Date}})</div>
@@ -128,7 +129,7 @@
         <div class="col--md-18">
             <article class="tile margin-left--1">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">Employment</span></h2></header>
-                <section class="col col--md-15">
+                <section class="col col--md-15 height-md--42">
                     <div class="margin-top--2 tile__subheading">Employment rate</div>
                     {{ if $EmploymentRate.Figure }}
                         <div class="margin-top-md--2">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
@@ -150,10 +151,10 @@
                     {{ end }}
                 </section>
                 <div class="col tile__split-bar print--hide width-md--14 margin-left-md--0 margin-top-md--3"></div>
-                <section class="col col--md-15">
+                <section class="col col--md-15 height-md--42">
                     <div class="margin-top--1 tile__subheading">Unemployment rate</div>
                     {{ if $UnemploymentRate.Figure }}
-                        <div class="margin-top-md--2">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
+                        <div class="margin-top-md--2">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $UnemploymentRate.Date}})</div>
                         <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
                         <p class="tile__trend">
                             <span class="tile__trend__icon">
@@ -323,7 +324,7 @@
                 <div class="col">
                     <div class="margin-top--1 tile__subheading"><b>Unemployment rate</b></div>
                     {{ if $UnemploymentRate.Figure }}
-                        <div class="">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date }})</div>
+                        <div class="">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $UnemploymentRate.Date }})</div>
                         <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
                         <p class="tile__trend">
                             <span class="tile__trend__icon">
@@ -347,5 +348,8 @@
     <button class="col btn btn--full-width btn--primary btn--focus tile__button hide--md hide--lg nojs--hide js-main-feature-compress-button"
             type="button">Show fewer ...
     </button>
+    {{ else }}
+        {{template "homepage/main-figures-none" .}}
+    {{ end }}
 </section>
 

--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -6,7 +6,6 @@
       {{ else if .Error -}}{{if .Error.Title }}{{ .Error.Title }}{{- end }}
       {{- end}} - {{ localise "OfficeForNationalStatistics" .Language 1 }}</title>
     {{if eq .Metadata.Title "Home"}}<meta name="description" content="{{ localise "HomepageDescription" .Language 1 }}">{{else}}<meta name="description" content="{{ .Metadata.Description}}">{{end}}
-    <meta name="keywords" content="{{range .Metadata.Keywords}} {{- .}}, {{end}}">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta charset="utf-8"/>
     <meta content="width=device-width,initial-scale=1.0,user-scalable=1" name="viewport">

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/5d7bec8"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/35c321c"
 	}
 	return cfg, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/ONSdigital/dp-frontend-models v1.7.0
+	github.com/ONSdigital/dp-frontend-models v1.9.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/go-ns v0.0.0-20200902154605-290c8b5ba5eb
 	github.com/ONSdigital/log.go v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,10 @@ github.com/ONSdigital/dp-frontend-models v1.6.0 h1:hWdFrm6bKlK0AD3HeY2CG2Idjzbfv
 github.com/ONSdigital/dp-frontend-models v1.6.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-frontend-models v1.7.0 h1:AZpriGMwNCA1mUt1ZpbPN6jo57wVXcG3E0DAoO6R6uQ=
 github.com/ONSdigital/dp-frontend-models v1.7.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
+github.com/ONSdigital/dp-frontend-models v1.8.0 h1:GnSO18hvjNGDblxNIEATXhGz32DO+H9eshkCAcbjFQY=
+github.com/ONSdigital/dp-frontend-models v1.8.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
+github.com/ONSdigital/dp-frontend-models v1.9.0 h1:Llgiapaec6VadA+bPdiMSEWykdVDTvDkbbC50ja68/4=
+github.com/ONSdigital/dp-frontend-models v1.9.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e h1:H2KVzsFp5oTbqjPXDlTHOB/LvYy2I6Mc8eSTLrmZkXs=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.2 h1:N8SzpYzdixVgJS9NMzTBA2RZ2bi3Am1wE5F8ROEpTYw=


### PR DESCRIPTION
### What

#### Dependency

The following must be deployed just before this is
- [x] https://github.com/ONSdigital/dp-frontend-filter-dataset-controller/pull/236
- [x] https://github.com/ONSdigital/dp-frontend-homepage-controller/pull/47

#### Release 1.31.0
- [x] [New Time Filter Option](https://trello.com/c/FpvgJIUs/408-save-and-return-button-required-at-top-of-long-checkbox-list-a-3) 
- [x] [Update styling on feedback form (Non-JS)](https://trello.com/c/3aMhIb42/530-update-styling-of-feedback-form-1) 
- [x] [Keywords metat tag removed](https://trello.com/c/Y03pxXl9/170-remove-keywords-meta-tag-05)
- [x] [Homepage graceful degradation](https://trello.com/c/Gdu6Kky1/476-graceful-degradation-states-for-homepage-2)
- [x] [Layout tweaks to legislate for up to 8 In Focus tiles (increased from 4)](https://trello.com/c/fLreJY8i/485-homepage-publish-journey-adding-upto-8-tiles-to-in-focus-section-1)
- [x] [Added canonical link to feedback page](https://trello.com/c/1KyLcrjM/4881-add-canonical-link-tag-to-feedback-page-s3)
- [x] [Updated feedback form to include previous URL, shown in editable text box](https://trello.com/c/JUMLuPgE/4882-standalone-feedback-form-is-displaying-the-this-specific-page-as-s3)
- [x] [Updated Feedback form so it is now accessible without 'service' query parameter](https://trello.com/c/1R99XlUh/4880-standalone-feedback-form-is-not-accessible-without-the-service-query-param-s3)

Noelles work I think that is contained in this. Would be good if someone else can verify/sanity check:
- [x] [Mobile 'other download options' box position](https://trello.com/c/V6LzMHEs/534-other-download-options-box-on-edition-page-and-preview-page-tb05)
- [x] [Beta Badge overflow fix (renderer side)](https://trello.com/c/w9C5jPyw/542-beta-badge-overflowing-beta-banner-1)

### How to review

Check that nothing has slipped into the release that shouldn't be in it
Check that everything in this release has been PO signed off

### Who can review

Anyone except me
