### PR TITLE
Update feedback bar styling and display by default

### DIFF
--- a/assets/templates/partials/feedback.tmpl
+++ b/assets/templates/partials/feedback.tmpl
@@ -1,19 +1,19 @@
 <div class="wrapper link-adjust">
     <div class="improve-this-page" data-module="improve-this-page">
         <div class="improve-this-page__prompt clearfix" id="feedback-form-header" tabindex="-1">
-            <h3 class="improve-this-page__is-useful-question">Is this page useful?</h3>
-            <a id="feedback-form-yes" class="improve-this-page__page-is-useful-button" href="/feedback/thanks">
+            <h3 class="improve-this-page__is-useful-question margin-right--1">Is this page useful?</h3>
+            <a id="feedback-form-yes" class="improve-this-page__page-is-useful-button" href="/feedback/thanks" aria-label="Yes I found this page useful">
                 Yes
             </a>
-            <a id="feedback-form-no" class="js-toggle" href="/feedback?service=cmd">
+            <span>|</span>
+            <a id="feedback-form-no" class="js-toggle" href="/feedback?service=cmd" aria-label="No I didn't find this page useful">
                 No
             </a>
             <a id="feedback-form-anything-wrong" class="js-toggle improve-this-page__anything-wrong" href="/feedback?service=cmd">
                 Can't find what you're looking for?
             </a>
         </div>
-        <div id="feedback-form" class="improve-this-page__form js-hidden">
-            <a href="javascript:void(0)" id="feedback-form-close" class="improve-this-page__close js-toggle">Close</a>
+        <div id="feedback-form" class="improve-this-page__form js-hidden font-size--18">  
             <form id="feedback-form-container">
                 <input type="hidden" name="feedback-form-type" value="footer">
                 <input type="hidden" name="url" id="feedback-form-url" value="">
@@ -24,10 +24,10 @@
                     <textarea id="description-field" class="form-control" name="description" rows="5"></textarea>
                 </div>
                 <div class="form-group">
-                    <label class="form-label-bold" for="name-field">
-                        Name (optional)
-                        <span class="form-hint">Include your name and email address if you'd like us to get back to you.</span>
-                    </label>
+                    <p class="font-size--24 font-weight-700 margin-bottom--0">Do you want a reply?</p>
+                    <p class="font-size--18 margin-top--0">If you'd like us to get back to you, please add your name and email address below.</p>
+
+                    <label class="form-label-bold" for="name-field">Name (optional)</label>
                     <input id="name-field" class="form-control" type="text" name="name">
                 </div>
                 <div class="form-group">
@@ -35,7 +35,10 @@
                     <input id="email-field" class="form-control" type="text" name="email">
                 </div>
                 <div>
-                    <input id="feedback-form-submit" class="btn btn--primary font-weight-700" type="submit" value="Send feedback">
+                    <input id="feedback-form-submit" class="btn btn--primary font-weight-700 margin-bottom--2" type="submit" value="Send feedback">
+                </div>
+                <div>
+                    <a href="javascript:void(0)" id="feedback-form-close" class="improve-this-page__close js-toggle btn btn--secondary font-weight-700">I don't want to provide feedback</a>
                 </div>
             </form>
         </div>

--- a/assets/templates/partials/footer.tmpl
+++ b/assets/templates/partials/footer.tmpl
@@ -1,8 +1,6 @@
 <footer class="print--hide padding-top--13">
    <section>
-      {{ if .ShowFeedbackForm }}
-         {{ template "partials/feedback" }}
-      {{ end }}
+      {{ template "partials/feedback" }}
       <h1 class="visuallyhidden">{{ localise "FooterLinks" .Language 1 }}</h2>
       <div class="footer">
          <div class="wrapper">

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/35c321c"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/e77558a"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What

- Update feedback bar styling
- Removed check for `ShowFeedbackForm` to display feedback bar on all pages (yes even error pages and feedback form page). [Product decision]


### Who can review

Anyone
