### PR TITLE
remove unnecessary meta tag

### DIFF
--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -6,7 +6,6 @@
       {{ else if .Error -}}{{if .Error.Title }}{{ .Error.Title }}{{- end }}
       {{- end}} - {{ localise "OfficeForNationalStatistics" .Language 1 }}</title>
     {{if eq .Metadata.Title "Home"}}<meta name="description" content="{{ localise "HomepageDescription" .Language 1 }}">{{else}}<meta name="description" content="{{ .Metadata.Description}}">{{end}}
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <meta charset="utf-8"/>
     <meta content="width=device-width,initial-scale=1.0,user-scalable=1" name="viewport">
     <meta name="format-detection" content="telephone=no">


### PR DESCRIPTION
### What

Remove unnecessary meta tags `cleartype` and `X-UA-Compatible` since these are no longer needed for IE11. 

### How to review

Go to any page and inspect it, see the meta tags `cleartype` and X-UA-Compatible`. Pull this branch, see these tags are no longer present. 

### Who can review

Anyone but me. 
