### PR TITLE
Temporarily remove main figure trends on homepage

### DIFF
--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -25,14 +25,6 @@
                     {{ if $EmploymentRate.Figure }}
                         <div class="margin-top-md--2 margin-top-lg--1 height-lg--11">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                         <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
-                        <p class="tile__trend">
-                            <span class="tile__trend__icon">
-                                {{if $EmploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                                {{if $EmploymentRate.Trend.IsDown}}&darr;{{ end }}
-                                {{if $EmploymentRate.Trend.IsFlat}}={{ end }}
-                            </span>
-                            <span class="tile__trend__text">{{ $EmploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $EmploymentRate.Trend.Period }}</span>
-                        </p>
                         <div class="margin-top--2">
                             <a href="{{ $EmploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for employment rate">Analysis</a>
                             <a href="{{ $EmploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for employment rate">Data</a>
@@ -46,14 +38,6 @@
                     {{ if $UnemploymentRate.Figure }}
                         <div class="margin-top-md--2 margin-top-lg--1 height-lg--11">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $UnemploymentRate.Date}})</div>
                         <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
-                        <p class="tile__trend">
-                            <span class="tile__trend__icon">
-                                {{if $UnemploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                                {{if $UnemploymentRate.Trend.IsDown}}&darr;{{ end }}
-                                {{if $UnemploymentRate.Trend.IsFlat}}={{ end }}
-                            </span>
-                            <span class="tile__trend__text">{{ $UnemploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $UnemploymentRate.Trend.Period }}</span>
-                        </p>
                         <div class="margin-top--2">
                             <a href="{{ $UnemploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for unemployment rate">Analysis</a>
                             <a href="{{ $UnemploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for unemployment rate">Data</a>
@@ -134,14 +118,6 @@
                     {{ if $EmploymentRate.Figure }}
                         <div class="margin-top-md--2">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                         <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
-                        <p class="tile__trend">
-                            <span class="tile__trend__icon">
-                                {{if $EmploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                                {{if $EmploymentRate.Trend.IsDown}}&darr;{{ end }}
-                                {{if $EmploymentRate.Trend.IsFlat}}={{ end }}
-                            </span>
-                            <span class="tile__trend__text">{{ $EmploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $EmploymentRate.Trend.Period }}</span>
-                        </p>
                         <div class="margin-top--2">
                             <a href="{{ $EmploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for employment rate">Analysis</a>
                             <a href="{{ $EmploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for employment rate">Data</a>
@@ -156,14 +132,6 @@
                     {{ if $UnemploymentRate.Figure }}
                         <div class="margin-top-md--2">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $UnemploymentRate.Date}})</div>
                         <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
-                        <p class="tile__trend">
-                            <span class="tile__trend__icon">
-                                {{if $UnemploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                                {{if $UnemploymentRate.Trend.IsDown}}&darr;{{ end }}
-                                {{if $UnemploymentRate.Trend.IsFlat}}={{ end }}
-                            </span>
-                            <span class="tile__trend__text">{{ $UnemploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $UnemploymentRate.Trend.Period }}</span>
-                        </p>
                         <div class="margin-top--2">
                             <a href="{{ $UnemploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for unemployment rate">Analysis</a>
                             <a href="{{ $UnemploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for unemployment rate">Data</a>
@@ -304,14 +272,7 @@
                         <div class="margin-top--1 tile__subheading"><b>Employment rate</b></div>
                         <div class="">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date }})</div>
                         <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
-                        <p class="tile__trend">
-                            <span class="tile__trend__icon">
-                                {{if $EmploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                                {{if $EmploymentRate.Trend.IsDown}}&darr;{{ end }}
-                                {{if $EmploymentRate.Trend.IsFlat}}={{ end }}
-                            </span>
-                            <span class="tile__trend__text">{{ $EmploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $EmploymentRate.Trend.Period }}</span>
-                        </p>
+
                         <div class="margin-top--1">
                             <a href="{{ $EmploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for employment rate">Analysis</a>
                             <a href="{{ $EmploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for employment rate">Data</a>
@@ -326,14 +287,6 @@
                     {{ if $UnemploymentRate.Figure }}
                         <div class="">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $UnemploymentRate.Date }})</div>
                         <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
-                        <p class="tile__trend">
-                            <span class="tile__trend__icon">
-                                {{if $UnemploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                                {{if $UnemploymentRate.Trend.IsDown}}&darr;{{ end }}
-                                {{if $UnemploymentRate.Trend.IsFlat}}={{ end }}
-                            </span>
-                            <span class="tile__trend__text">{{ $UnemploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $UnemploymentRate.Trend.Period }}</span>
-                        </p>
                         <div class="margin-top--1">
                             <a href="{{ $UnemploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for unemployment rate">Analysis</a>
                             <a href="{{ $UnemploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for unemployment rate">Data</a>


### PR DESCRIPTION
### What

Trend indicator is wrong on employment and unemployment. Whilst this issue is being investigated these indicators are to be removed to reduce confusion and possibility of showing wrong values

### How to review

Check homepage that the employment and unemployment main figures section no longer show the trend indicators.

Check this on multiple browsers and viewports to ensure homepage doesn't start behaving weird. e.g. misalign

### Who can review

Frontend dev
