### PR TITLE
HOTFIX RELEASE - Remove trend indicators for employment and unemployment

### DIFF
--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -25,14 +25,6 @@
                     {{ if $EmploymentRate.Figure }}
                         <div class="margin-top-md--2 margin-top-lg--1 height-lg--11">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                         <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
-                        <p class="tile__trend">
-                            <span class="tile__trend__icon">
-                                {{if $EmploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                                {{if $EmploymentRate.Trend.IsDown}}&darr;{{ end }}
-                                {{if $EmploymentRate.Trend.IsFlat}}={{ end }}
-                            </span>
-                            <span class="tile__trend__text">{{ $EmploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $EmploymentRate.Trend.Period }}</span>
-                        </p>
                         <div class="margin-top--2">
                             <a href="{{ $EmploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for employment rate">Analysis</a>
                             <a href="{{ $EmploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for employment rate">Data</a>
@@ -46,14 +38,6 @@
                     {{ if $UnemploymentRate.Figure }}
                         <div class="margin-top-md--2 margin-top-lg--1 height-lg--11">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $UnemploymentRate.Date}})</div>
                         <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
-                        <p class="tile__trend">
-                            <span class="tile__trend__icon">
-                                {{if $UnemploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                                {{if $UnemploymentRate.Trend.IsDown}}&darr;{{ end }}
-                                {{if $UnemploymentRate.Trend.IsFlat}}={{ end }}
-                            </span>
-                            <span class="tile__trend__text">{{ $UnemploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $UnemploymentRate.Trend.Period }}</span>
-                        </p>
                         <div class="margin-top--2">
                             <a href="{{ $UnemploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for unemployment rate">Analysis</a>
                             <a href="{{ $UnemploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for unemployment rate">Data</a>
@@ -134,14 +118,6 @@
                     {{ if $EmploymentRate.Figure }}
                         <div class="margin-top-md--2">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date}})</div>
                         <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
-                        <p class="tile__trend">
-                            <span class="tile__trend__icon">
-                                {{if $EmploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                                {{if $EmploymentRate.Trend.IsDown}}&darr;{{ end }}
-                                {{if $EmploymentRate.Trend.IsFlat}}={{ end }}
-                            </span>
-                            <span class="tile__trend__text">{{ $EmploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $EmploymentRate.Trend.Period }}</span>
-                        </p>
                         <div class="margin-top--2">
                             <a href="{{ $EmploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for employment rate">Analysis</a>
                             <a href="{{ $EmploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for employment rate">Data</a>
@@ -156,14 +132,6 @@
                     {{ if $UnemploymentRate.Figure }}
                         <div class="margin-top-md--2">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $UnemploymentRate.Date}})</div>
                         <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
-                        <p class="tile__trend">
-                            <span class="tile__trend__icon">
-                                {{if $UnemploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                                {{if $UnemploymentRate.Trend.IsDown}}&darr;{{ end }}
-                                {{if $UnemploymentRate.Trend.IsFlat}}={{ end }}
-                            </span>
-                            <span class="tile__trend__text">{{ $UnemploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $UnemploymentRate.Trend.Period }}</span>
-                        </p>
                         <div class="margin-top--2">
                             <a href="{{ $UnemploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for unemployment rate">Analysis</a>
                             <a href="{{ $UnemploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for unemployment rate">Data</a>
@@ -304,14 +272,6 @@
                         <div class="margin-top--1 tile__subheading"><b>Employment rate</b></div>
                         <div class="">Aged 16 to 64 seasonally adjusted ({{ DatePeriodFormat $EmploymentRate.Date }})</div>
                         <div class="tile__figure">{{ $EmploymentRate.Figure }}{{ $EmploymentRate.Unit }}</div>
-                        <p class="tile__trend">
-                            <span class="tile__trend__icon">
-                                {{if $EmploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                                {{if $EmploymentRate.Trend.IsDown}}&darr;{{ end }}
-                                {{if $EmploymentRate.Trend.IsFlat}}={{ end }}
-                            </span>
-                            <span class="tile__trend__text">{{ $EmploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $EmploymentRate.Trend.Period }}</span>
-                        </p>
                         <div class="margin-top--1">
                             <a href="{{ $EmploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for employment rate">Analysis</a>
                             <a href="{{ $EmploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for employment rate">Data</a>
@@ -326,14 +286,6 @@
                     {{ if $UnemploymentRate.Figure }}
                         <div class="">Aged 16+ seasonally adjusted ({{ DatePeriodFormat $UnemploymentRate.Date }})</div>
                         <div class="tile__figure">{{ $UnemploymentRate.Figure }}{{ $UnemploymentRate.Unit }}</div>
-                        <p class="tile__trend">
-                            <span class="tile__trend__icon">
-                                {{if $UnemploymentRate.Trend.IsUp}}&uarr;{{ end }}
-                                {{if $UnemploymentRate.Trend.IsDown}}&darr;{{ end }}
-                                {{if $UnemploymentRate.Trend.IsFlat}}={{ end }}
-                            </span>
-                            <span class="tile__trend__text">{{ $UnemploymentRate.Trend.Difference }} {{ localise "OnPrevious" .Language 1 }} {{ $UnemploymentRate.Trend.Period }}</span>
-                        </p>
                         <div class="margin-top--1">
                             <a href="{{ $UnemploymentRate.FigureURIs.Analysis }}" class="tile__link" aria-label="Analysis for unemployment rate">Analysis</a>
                             <a href="{{ $UnemploymentRate.FigureURIs.Data }}" class="tile__link margin-left--1" aria-label="Data for unemployment rate">Data</a>


### PR DESCRIPTION
### What

We need to remove the trend indicators ASAP on the homepage for employment and unemployment
Note this contains the changes from https://github.com/ONSdigital/dp-frontend-renderer/pull/541 . 
These changes are desired to go into production before other tasks on develop are signed off.

### How to review

Check that these indicators have been removed and that everything still aligns ok on the homepage

### Who can review

Frontend dev or TL
