### PR TITLE
remove unnecessary attribute

### DIFF
--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -48,7 +48,7 @@
     {{ end }}
     {{ template "partials/header" . }}
 
-    <main id="main" role="main" tabindex="-1">
+    <main id="main" tabindex="-1">
       {{yield}}
     </main>
 

--- a/assets/templates/search.tmpl
+++ b/assets/templates/search.tmpl
@@ -1,7 +1,7 @@
 <div class="search search--results-page print--hide" id="searchBar">
     {{ template "search/bar" . }}
 </div>
-<main id="main" role="main" tabindex="-1">
+<main id="main" tabindex="-1">
     <div class="page-content border">
         <div class="wrapper">
             {{ template "search/sort" . }}


### PR DESCRIPTION
### What

`role="main"` attribute is unnecessary since semantic HTML `<main>` element is used. 

### How to review

Inspect any page on develop and within the `main` element see there is `role="main"`. Pull this branch, inspect page and see there is no `role="main"` within the `main` element.

### Who can review

Anyone but me. 
