### PR TITLE
remove code for browers no longer supported

### DIFF
--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -12,15 +12,7 @@
     <meta name="theme-color" content="#58595B">
     <meta name="apple-mobile-web-app-status-bar-style" content="#58595B">
     {{ if .Metadata.ServiceName }}<meta name="ons:service" content="{{ .Metadata.ServiceName}}">{{ end }}
-		{{`<!--[if lte IE 8]>` | safeHTML}}
-      <link rel="stylesheet" href="{{.PatternLibraryAssetsPath}}/css/old-ie.css">
-		{{`<![endif]-->` | safeHTML}}
-    {{`<!--[if IE 9]>` | safeHTML}}
-      <link rel="stylesheet" href="{{.PatternLibraryAssetsPath}}/css/ie-9.css">
-    {{`<![endif]-->` | safeHTML}}
-		{{`<!--[if gt IE 9]><!-->` | safeHTML}}
-      <link rel="stylesheet" href="{{.PatternLibraryAssetsPath}}/css/main.css">
-    {{`<!--<![endif]-->` | safeHTML}}
+    <link rel="stylesheet" href="{{.PatternLibraryAssetsPath}}/css/main.css">
     {{ if .HasJSONLD -}}{{ template "partials/json-ld/base" . }}{{- end }}
 
     {{if eq .Metadata.Title "Feedback"}}
@@ -54,10 +46,8 @@
 
     {{ template "partials/footer" . }}
 
-    {{`<!--[if gt IE 8]><!-->` | safeHTML}}
       {{/* TODO - update on live build to use two JS files, not a single one */}}
-      <script type="text/javascript" src="{{.PatternLibraryAssetsPath}}/js/main.js"></script>
-      <script type="text/javascript" src="/js/app.js"></script>
-    {{`<!--<![endif]-->` | safeHTML}}
+    <script type="text/javascript" src="{{.PatternLibraryAssetsPath}}/js/main.js"></script>
+    <script type="text/javascript" src="/js/app.js"></script>
 </body>
 </html>

--- a/assets/templates/partials/header.tmpl
+++ b/assets/templates/partials/header.tmpl
@@ -6,12 +6,7 @@
         <div class="header col-wrap">
             <div class="col col--lg-one-third col--md-one-third">
                 <a id="logo-link" href="/">
-                    {{`<!--[if lte IE 8]>` | safeHTML}}
-                        <img class="logo" src="https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.png" alt="{{ localise "ONSLogoAlt" .Language 1 }}">
-                    {{`<![endif]-->` | safeHTML}}
-                    {{`<!--[if gte IE 9]><!-->` | safeHTML}}
-                        <img class="logo" src="https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.svg" alt="{{ localise "ONSLogoAlt" .Language 1 }}">
-                    {{`<![endif]-->` | safeHTML}}
+                    <img class="logo" src="https://cdn.ons.gov.uk/assets/images/ons-logo/v2/ons-logo.svg" alt="{{ localise "ONSLogoAlt" .Language 1 }}">
                 </a>
             </div>
             <div class="col col--lg-two-thirds col--md-two-thirds hide--sm print--hide language--js__container">


### PR DESCRIPTION
### What

Remove conditional formatting for browsers older than IE11 since we no longer support these browsers.

### How to review

Inspect any page, see conditional formatting that supports older IE browsers. Pull this branch, inspect any page and see there is no longer conditional formatting.

### Who can review

Anyone but me.
