### PR TITLE
Update font on CMD pages

### DIFF
--- a/assets/templates/dataset-filter/age.tmpl
+++ b/assets/templates/dataset-filter/age.tmpl
@@ -22,15 +22,15 @@
         </div>
     </div>
 </div>
-<div class="adjust-font-size--18 line-height—32">
+<div class="adjust-font-size--18 line-height--32">
     <div class="page-content underline-all-links">
         <div class="wrapper">
             <div class="col col--md-47 col--lg-59">
                 <div class="col col--md-29 col--lg-29">
-                    <p class="font-size--18 line-height—32">Ages {{.Data.Youngest}} to {{.Data.Oldest}} available in this dataset</p>
+                    <p class="font-size--18 line-height--32">Ages {{.Data.Youngest}} to {{.Data.Oldest}} available in this dataset</p>
                 </div>
                 <form id="age-form" method="post" action="{{.Data.FormAction.URL}}">
-                    <div class="form adjust-font-size--18 line-height—32 clear-left">
+                    <div class="form adjust-font-size--18 line-height--32 clear-left">
                         <div class="col col--md-29 col--lg-29 margin-top--2">
                             <fieldset class="margin-bottom--6">
                                 <legend class="visuallyhidden">Select a method to filter the dataset for Age</legend>
@@ -79,7 +79,7 @@
                                                                 </div>
                                                                 <div id="add-all-save-and-return" class="margin-left-md--5  margin-left-lg--8  inline-block">
                                                                     <div class="hide--md-only hide--sm">
-                                                                        <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height—32 text-wrap full-width" value="Save and return">
+                                                                        <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height--32 text-wrap full-width" value="Save and return">
                                                                     </div>
                                                                 </div>
                                                                 {{ range $i, $v := .Data.Ages }}
@@ -99,7 +99,7 @@
                                 </div>
                             </fieldset>
                             <div id="save-and-return-container" class="col--md-20 col--lg-20 width-sm--20 margin-bottom--8">
-                                <input name="save-and-return" id="age-save-and-return" class="btn btn--primary btn--thick btn--full-width btn--big btn--focus font-weight-700 font-size--18 line-height—32" type="submit" value="Save and return" />
+                                <input name="save-and-return" id="age-save-and-return" class="btn btn--primary btn--thick btn--full-width btn--big btn--focus font-weight-700 font-size--18 line-height--32" type="submit" value="Save and return" />
                             </div>
                         </div>
                     </div>

--- a/assets/templates/dataset-filter/age.tmpl
+++ b/assets/templates/dataset-filter/age.tmpl
@@ -27,10 +27,10 @@
         <div class="wrapper">
             <div class="col col--md-47 col--lg-59">
                 <div class="col col--md-29 col--lg-29">
-                    <p class="font-size--18 line-height--32">Ages {{.Data.Youngest}} to {{.Data.Oldest}} available in this dataset</p>
+                    <p class="line-height--32">Ages {{.Data.Youngest}} to {{.Data.Oldest}} available in this dataset</p>
                 </div>
                 <form id="age-form" method="post" action="{{.Data.FormAction.URL}}">
-                    <div class="form adjust-font-size--18 line-height--32 clear-left">
+                    <div class="form line-height--32 clear-left">
                         <div class="col col--md-29 col--lg-29 margin-top--2">
                             <fieldset class="margin-bottom--6">
                                 <legend class="visuallyhidden">Select a method to filter the dataset for Age</legend>
@@ -79,7 +79,7 @@
                                                                 </div>
                                                                 <div id="add-all-save-and-return" class="margin-left-md--5  margin-left-lg--8  inline-block">
                                                                     <div class="hide--md-only hide--sm">
-                                                                        <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height--32 text-wrap full-width" value="Save and return">
+                                                                        <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 line-height--32 text-wrap full-width" value="Save and return">
                                                                     </div>
                                                                 </div>
                                                                 {{ range $i, $v := .Data.Ages }}

--- a/assets/templates/dataset-filter/age.tmpl
+++ b/assets/templates/dataset-filter/age.tmpl
@@ -4,7 +4,7 @@
             <div class="col">
                 {{ template "partials/breadcrumb" . }}
                 <div class="col col--md-47 col--lg-39">
-                    <h1 class="page-intro__title font-weight-700">Age</h1>
+                    <h1 class="page-intro__title font-size--38 line-height--48 font-weight-700">Age</h1>
                     {{if .Metadata.Description}}
                     <div class="font-size--16">
                         <details class="margin-bottom--2 margin-bottom--2">
@@ -22,15 +22,15 @@
         </div>
     </div>
 </div>
-<div class="adjust-font-size--16">
+<div class="adjust-font-size--18">
     <div class="page-content underline-all-links">
         <div class="wrapper">
             <div class="col col--md-47 col--lg-59">
                 <div class="col col--md-29 col--lg-29">
-                    <p class="font-size--17">Ages {{.Data.Youngest}} to {{.Data.Oldest}} available in this dataset</p>
+                    <p class="font-size--18">Ages {{.Data.Youngest}} to {{.Data.Oldest}} available in this dataset</p>
                 </div>
                 <form id="age-form" method="post" action="{{.Data.FormAction.URL}}">
-                    <div class="form adjust-font-size--16 clear-left">
+                    <div class="form adjust-font-size--18 clear-left">
                         <div class="col col--md-29 col--lg-29 margin-top--2">
                             <fieldset class="margin-bottom--6">
                                 <legend class="visuallyhidden">Select a method to filter the dataset for Age</legend>
@@ -79,7 +79,7 @@
                                                                 </div>
                                                                 <div id="add-all-save-and-return" class="margin-left-md--5  margin-left-lg--8  inline-block">
                                                                     <div class="hide--md-only hide--sm">
-                                                                        <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap full-width" value="Save and return">
+                                                                        <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 text-wrap full-width" value="Save and return">
                                                                     </div>
                                                                 </div>
                                                                 {{ range $i, $v := .Data.Ages }}
@@ -99,7 +99,7 @@
                                 </div>
                             </fieldset>
                             <div id="save-and-return-container" class="col--md-20 col--lg-20 width-sm--20 margin-bottom--8">
-                                <input name="save-and-return" id="age-save-and-return" class="btn btn--primary btn--thick btn--full-width btn--big btn--focus font-weight-700 font-size--17" type="submit" value="Save and return" />
+                                <input name="save-and-return" id="age-save-and-return" class="btn btn--primary btn--thick btn--full-width btn--big btn--focus font-weight-700 font-size--18" type="submit" value="Save and return" />
                             </div>
                         </div>
                     </div>

--- a/assets/templates/dataset-filter/age.tmpl
+++ b/assets/templates/dataset-filter/age.tmpl
@@ -51,14 +51,14 @@
                                             <div class="clearfix">
                                                 <div class="col col--md-8 col--lg-8">
                                                     <label class="block margin-bottom--1" for="age-youngest">Youngest</label>
-                                                    <input name="youngest" class="filters__age--text" value="{{.Data.FirstSelected}}" id="age-youngest" />
+                                                    <input name="youngest" class="filters__age--text line-height--32" value="{{.Data.FirstSelected}}" id="age-youngest" />
                                                 </div>
                                                 <div class="col col--md-2 col--lg-2 margin-right--1 padding-top--2">
-                                                    <p class="font-size--16 block">to</p>
+                                                    <p class="font-size--18 line-height--32 block">to</p>
                                                 </div>
                                                 <div class="col col--md-8 col--lg-8">
                                                     <label class="block margin-bottom--1" for="age-oldest">Oldest</label>
-                                                    <input name="oldest" class="filters__age--text" value="{{.Data.LastSelected}}" id="age-oldest"/>
+                                                    <input name="oldest" class="filters__age--text line-height--32" value="{{.Data.LastSelected}}" id="age-oldest"/>
                                                 </div>
                                             </div>
                                         </div>

--- a/assets/templates/dataset-filter/age.tmpl
+++ b/assets/templates/dataset-filter/age.tmpl
@@ -22,15 +22,15 @@
         </div>
     </div>
 </div>
-<div class="adjust-font-size--18">
+<div class="adjust-font-size--18 line-height—32">
     <div class="page-content underline-all-links">
         <div class="wrapper">
             <div class="col col--md-47 col--lg-59">
                 <div class="col col--md-29 col--lg-29">
-                    <p class="font-size--18">Ages {{.Data.Youngest}} to {{.Data.Oldest}} available in this dataset</p>
+                    <p class="font-size--18 line-height—32">Ages {{.Data.Youngest}} to {{.Data.Oldest}} available in this dataset</p>
                 </div>
                 <form id="age-form" method="post" action="{{.Data.FormAction.URL}}">
-                    <div class="form adjust-font-size--18 clear-left">
+                    <div class="form adjust-font-size--18 line-height—32 clear-left">
                         <div class="col col--md-29 col--lg-29 margin-top--2">
                             <fieldset class="margin-bottom--6">
                                 <legend class="visuallyhidden">Select a method to filter the dataset for Age</legend>
@@ -79,7 +79,7 @@
                                                                 </div>
                                                                 <div id="add-all-save-and-return" class="margin-left-md--5  margin-left-lg--8  inline-block">
                                                                     <div class="hide--md-only hide--sm">
-                                                                        <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 text-wrap full-width" value="Save and return">
+                                                                        <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height—32 text-wrap full-width" value="Save and return">
                                                                     </div>
                                                                 </div>
                                                                 {{ range $i, $v := .Data.Ages }}
@@ -99,7 +99,7 @@
                                 </div>
                             </fieldset>
                             <div id="save-and-return-container" class="col--md-20 col--lg-20 width-sm--20 margin-bottom--8">
-                                <input name="save-and-return" id="age-save-and-return" class="btn btn--primary btn--thick btn--full-width btn--big btn--focus font-weight-700 font-size--18" type="submit" value="Save and return" />
+                                <input name="save-and-return" id="age-save-and-return" class="btn btn--primary btn--thick btn--full-width btn--big btn--focus font-weight-700 font-size--18 line-height—32" type="submit" value="Save and return" />
                             </div>
                         </div>
                     </div>

--- a/assets/templates/dataset-filter/filter-overview.tmpl
+++ b/assets/templates/dataset-filter/filter-overview.tmpl
@@ -4,13 +4,13 @@
             <div class="col">
                 {{ template "partials/breadcrumb" . }}
                 <div class="col col--md-47 col--lg-39">
-                    <h1 class="page-intro__title font-weight-700 margin-bottom--0">Filter options</h1>
+                    <h1 class="page-intro__title font-size--38 line-height--48 font-weight-700 margin-bottom--0">Filter options</h1>
                 </div>
             </div>
         </div>
     </div>
 </div>
-<div class="adjust-font-size--16">
+<div class="adjust-font-size--18">
     <div class="page-content link-adjust">
         <div class="wrapper padding-right-sm--0 padding-left-sm--0">
             <div id="options-info" class="col-wrap">
@@ -49,7 +49,7 @@
                         </ul>
                         <div class="padding-bottom--4 padding-left--2 padding-top--2">
                             <form method="post" action="/filters/{{.FilterID}}/submit">
-                                <input id="preview-download" type="submit" value="Apply filters" aria-label="Apply filters" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--17" name="preview-and-download" />
+                                <input id="preview-download" type="submit" value="Apply filters" aria-label="Apply filters" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18" name="preview-and-download" />
                             </form>
                         </div>
                     </div>

--- a/assets/templates/dataset-filter/filter-overview.tmpl
+++ b/assets/templates/dataset-filter/filter-overview.tmpl
@@ -10,7 +10,7 @@
         </div>
     </div>
 </div>
-<div class="adjust-font-size--18">
+<div class="adjust-font-size--18 line-height—32">
     <div class="page-content link-adjust">
         <div class="wrapper padding-right-sm--0 padding-left-sm--0">
             <div id="options-info" class="col-wrap">
@@ -49,7 +49,7 @@
                         </ul>
                         <div class="padding-bottom--4 padding-left--2 padding-top--2">
                             <form method="post" action="/filters/{{.FilterID}}/submit">
-                                <input id="preview-download" type="submit" value="Apply filters" aria-label="Apply filters" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18" name="preview-and-download" />
+                                <input id="preview-download" type="submit" value="Apply filters" aria-label="Apply filters" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height—32" name="preview-and-download" />
                             </form>
                         </div>
                     </div>

--- a/assets/templates/dataset-filter/filter-overview.tmpl
+++ b/assets/templates/dataset-filter/filter-overview.tmpl
@@ -28,7 +28,7 @@
                                 <div class="col--lg-56 min-height--10 padding-left-sm--0 padding-left-md--1">
                                     {{$length := len .AddedCategories}}{{$categories := .AddedCategories}}
                                     <div class="col col--md-8 col--lg-8 min-height--4">
-                                        <a class="{{if eq .Link.Label "Edit"}}filter-overview__link--edit{{else}}filter-overview__link--add{{end}}" href="{{.Link.URL}}"><span class="dimension-button {{if eq .Link.Label "Add"}}btn btn--tertiary margin-left-md--2 margin-left-sm--1 {{else}}margin-left-md--3 margin-left-sm--2 {{end}} font-weight-700 ">{{.Link.Label}} <span class="visuallyhidden">{{if gt $length 0}}by {{end}}{{.Filter}}</span></span></a>
+                                        <a class="{{if eq .Link.Label "Edit"}}filter-overview__link--edit{{else}}filter-overview__link--add{{end}}" href="{{.Link.URL}}"><span class="line-height--32 dimension-button {{if eq .Link.Label "Add"}}btn btn--tertiary margin-left-md--2 margin-left-sm--1 {{else}}margin-left-md--3 margin-left-sm--2 {{end}} font-weight-700 ">{{.Link.Label}} <span class="visuallyhidden">{{if gt $length 0}}by {{end}}{{.Filter}}</span></span></a>
                                     </div>
                                     <div class="dimension-name col col--md-11 col--lg-14 margin-left-sm--6 height-sm--3 height-md--6 overflow--hidden margin-top-md--3 margin-bottom-sm--2"><strong><span class="js-filter-option-label font-size--16">{{.Filter}}</span></strong></div>
                                     <div id="number-added-{{slug .Filter}}" class="col col--md-20 col--lg-30">

--- a/assets/templates/dataset-filter/filter-overview.tmpl
+++ b/assets/templates/dataset-filter/filter-overview.tmpl
@@ -10,7 +10,7 @@
         </div>
     </div>
 </div>
-<div class="adjust-font-size--18 line-height—32">
+<div class="adjust-font-size--18 line-height--32">
     <div class="page-content link-adjust">
         <div class="wrapper padding-right-sm--0 padding-left-sm--0">
             <div id="options-info" class="col-wrap">
@@ -19,12 +19,12 @@
                   {{ template "partials/latest-release-alert" . }}
 	            {{ end }}
                     <div class="col col--md-47 col--lg-59 margin-top--2 margin-bottom--4 background--gallery">
-                        <ul class="list--neutral filter-overview">
-                            <li class="margin-left--0 padding-bottom--2 padding-top--0 padding-right--2 width-lg--56">
+                        <ul class="list--neutral filter-overview ">
+                            <li class="font-size--18 line-height--32 margin-left--0 padding-bottom--2 padding-top--0 padding-right--2 width-lg--56">
                         	    <a class="float-el--right-md float-el--right-sm float-el--right-lg" href="{{.Data.ClearAll.URL}}">Clear filters</a>
                             </li>
                             {{ range .Data.Dimensions}}
-                            <li class="js-filter-option white-background margin-left-md--2 margin-right-md--2 margin-right-sm--1 margin-left-sm--1 {{if eq .Link.Label "Add"}}filter-overview__add{{else}}filter-overview__edit{{end}}">
+                            <li class="font-size--18 line-height--32 js-filter-option white-background margin-left-md--2 margin-right-md--2 margin-right-sm--1 margin-left-sm--1 {{if eq .Link.Label "Add"}}filter-overview__add{{else}}filter-overview__edit{{end}}">
                                 <div class="col--lg-56 min-height--10 padding-left-sm--0 padding-left-md--1">
                                     {{$length := len .AddedCategories}}{{$categories := .AddedCategories}}
                                     <div class="col col--md-8 col--lg-8 min-height--4">
@@ -35,9 +35,9 @@
                                         <div class="font-size--16 height-sm--3 height-md--10 nowrap-sm vertical-align-middle margin-left-sm--4 list--ellipses-sm overflow--hidden">
                                         <div class="height-sm--3 max-height-md--9 vertical-align-middle__contents--md list--ellipses-md">
                                             <ul class="list list--pipe-seperated list--pipe-seperated-ellipses">
-                                                <li class="list--no-separator">{{if eq $length 0}}Nothing added{{else}}{{$length}} added:{{end}}</li>
+                                                <li class="font-size--18 line-height--32 list--no-separator">{{if eq $length 0}}Nothing added{{else}}{{$length}} added:{{end}}</li>
                                                 {{range $i, $c := $categories}}
-                                                    <li>{{$c}}</li>
+                                                    <li class="font-size--18 line-height--32">{{$c}}</li>
                                                 {{end}}
                                             </ul>
                                         </div>
@@ -49,7 +49,7 @@
                         </ul>
                         <div class="padding-bottom--4 padding-left--2 padding-top--2">
                             <form method="post" action="/filters/{{.FilterID}}/submit">
-                                <input id="preview-download" type="submit" value="Apply filters" aria-label="Apply filters" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height—32" name="preview-and-download" />
+                                <input id="preview-download" type="submit" value="Apply filters" aria-label="Apply filters" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height--32" name="preview-and-download" />
                             </form>
                         </div>
                     </div>

--- a/assets/templates/dataset-filter/filter-overview.tmpl
+++ b/assets/templates/dataset-filter/filter-overview.tmpl
@@ -30,9 +30,9 @@
                                     <div class="col col--md-8 col--lg-8 min-height--4">
                                         <a class="{{if eq .Link.Label "Edit"}}filter-overview__link--edit{{else}}filter-overview__link--add{{end}}" href="{{.Link.URL}}"><span class="line-height--32 dimension-button {{if eq .Link.Label "Add"}}btn btn--tertiary margin-left-md--2 margin-left-sm--1 {{else}}margin-left-md--3 margin-left-sm--2 {{end}} font-weight-700 ">{{.Link.Label}} <span class="visuallyhidden">{{if gt $length 0}}by {{end}}{{.Filter}}</span></span></a>
                                     </div>
-                                    <div class="dimension-name col col--md-11 col--lg-14 margin-left-sm--6 height-sm--3 height-md--6 overflow--hidden margin-top-md--3 margin-bottom-sm--2"><strong><span class="js-filter-option-label font-size--16">{{.Filter}}</span></strong></div>
+                                    <div class="dimension-name col col--md-11 col--lg-14 margin-left-sm--6 height-sm--3 height-md--6 overflow--hidden margin-top-md--3 margin-bottom-sm--2"><strong><span class="js-filter-option-label font-size--18 line-height--32">{{.Filter}}</span></strong></div>
                                     <div id="number-added-{{slug .Filter}}" class="col col--md-20 col--lg-30">
-                                        <div class="font-size--16 height-sm--3 height-md--10 nowrap-sm vertical-align-middle margin-left-sm--4 list--ellipses-sm overflow--hidden">
+                                        <div class="font-size--18 line-height--32 height-sm--3 height-md--10 nowrap-sm vertical-align-middle margin-left-sm--4 list--ellipses-sm overflow--hidden">
                                         <div class="height-sm--3 max-height-md--9 vertical-align-middle__contents--md list--ellipses-md">
                                             <ul class="list list--pipe-seperated list--pipe-seperated-ellipses">
                                                 <li class="line-height--32 list--no-separator">{{if eq $length 0}}Nothing added{{else}}{{$length}} added:{{end}}</li>

--- a/assets/templates/dataset-filter/filter-overview.tmpl
+++ b/assets/templates/dataset-filter/filter-overview.tmpl
@@ -20,11 +20,11 @@
 	            {{ end }}
                     <div class="col col--md-47 col--lg-59 margin-top--2 margin-bottom--4 background--gallery">
                         <ul class="list--neutral filter-overview ">
-                            <li class="font-size--18 line-height--32 margin-left--0 padding-bottom--2 padding-top--0 padding-right--2 width-lg--56">
+                            <li class="line-height--32 margin-left--0 padding-bottom--2 padding-top--0 padding-right--2 width-lg--56">
                         	    <a class="float-el--right-md float-el--right-sm float-el--right-lg" href="{{.Data.ClearAll.URL}}">Clear filters</a>
                             </li>
                             {{ range .Data.Dimensions}}
-                            <li class="font-size--18 line-height--32 js-filter-option white-background margin-left-md--2 margin-right-md--2 margin-right-sm--1 margin-left-sm--1 {{if eq .Link.Label "Add"}}filter-overview__add{{else}}filter-overview__edit{{end}}">
+                            <li class="line-height--32 js-filter-option white-background margin-left-md--2 margin-right-md--2 margin-right-sm--1 margin-left-sm--1 {{if eq .Link.Label "Add"}}filter-overview__add{{else}}filter-overview__edit{{end}}">
                                 <div class="col--lg-56 min-height--10 padding-left-sm--0 padding-left-md--1">
                                     {{$length := len .AddedCategories}}{{$categories := .AddedCategories}}
                                     <div class="col col--md-8 col--lg-8 min-height--4">
@@ -35,9 +35,9 @@
                                         <div class="font-size--16 height-sm--3 height-md--10 nowrap-sm vertical-align-middle margin-left-sm--4 list--ellipses-sm overflow--hidden">
                                         <div class="height-sm--3 max-height-md--9 vertical-align-middle__contents--md list--ellipses-md">
                                             <ul class="list list--pipe-seperated list--pipe-seperated-ellipses">
-                                                <li class="font-size--18 line-height--32 list--no-separator">{{if eq $length 0}}Nothing added{{else}}{{$length}} added:{{end}}</li>
+                                                <li class="line-height--32 list--no-separator">{{if eq $length 0}}Nothing added{{else}}{{$length}} added:{{end}}</li>
                                                 {{range $i, $c := $categories}}
-                                                    <li class="font-size--18 line-height--32">{{$c}}</li>
+                                                    <li class="line-height--32">{{$c}}</li>
                                                 {{end}}
                                             </ul>
                                         </div>
@@ -49,7 +49,7 @@
                         </ul>
                         <div class="padding-bottom--4 padding-left--2 padding-top--2">
                             <form method="post" action="/filters/{{.FilterID}}/submit">
-                                <input id="preview-download" type="submit" value="Apply filters" aria-label="Apply filters" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height--32" name="preview-and-download" />
+                                <input id="preview-download" type="submit" value="Apply filters" aria-label="Apply filters" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 line-height--32" name="preview-and-download" />
                             </form>
                         </div>
                     </div>

--- a/assets/templates/dataset-filter/hierarchy.tmpl
+++ b/assets/templates/dataset-filter/hierarchy.tmpl
@@ -29,8 +29,8 @@
                 <div class="col col--md-50 col--lg-35 margin-left-md--1">
                     <form class="margin-bottom--2" action="{{.Data.SearchURL}}">
                         <div class="clearfix">
-                            <label for="search" class="block font-size--18 line-height--32 padding-bottom--2 font-weight-700">Search <span class="visuallyhidden">{{ .Data.DimensionName }}</span></label>
-                            <input type="search" id="search" autocomplete="off" class="search__input search__input--body col col--md-31 col--lg-31" name="q" {{if .Data.IsSearchResults}} value="{{.Data.Query}}" {{end}} placeholder="Search {{.Data.DimensionName}}">
+                            <label for="search" class="block line-height--32 padding-bottom--2 font-weight-700">Search <span class="visuallyhidden">{{ .Data.DimensionName }}</span></label>
+                            <input type="search" id="search" autocomplete="off" class="search__input search__input--body line-height--32 col col--md-31 col--lg-31" name="q" {{if .Data.IsSearchResults}} value="{{.Data.Query}}" {{end}} placeholder="Search {{.Data.DimensionName}}">
                             <button type="submit" class="search__button search__button--body col--md-3 col--lg-3" id="nav-search-submit">
                                 <span class="visuallyhidden">Search</span>
                                 <span class="icon icon-search--light"></span>
@@ -45,7 +45,7 @@
                         <fieldset>
                             <legend>
                                 {{if .Data.IsSearchResults}}
-                                    <div class="font-size--18 line-height--32 padding-bottom--2 margin-top--2">
+                                    <div class="line-height--32 padding-bottom--2 margin-top--2">
                                         <a id="back" href="{{ .Data.GoBack.URL }}">
                                             <span class="icon icon-arrow-back--dark-small"></span>Back
                                         </a>
@@ -69,16 +69,16 @@
                                 <div class="no-results-advice">
                                     <h3>Please try:</h3>
                                     <ul>
-                                        <li class="font-size--18 line-height--32">Making sure that all words are spelled correctly</li>
-                                        <li class="font-size--18 line-height--32">Searching again using different words</li>
-                                        <li class="font-size--18 line-height--32">Check the dataset includes this <a href="{{.Data.LandingPageURL}}">{{.Data.DimensionName}}</a> option</li>
+                                        <li class="line-height--32">Making sure that all words are spelled correctly</li>
+                                        <li class="line-height--32">Searching again using different words</li>
+                                        <li class="line-height--32">Check the dataset includes this <a href="{{.Data.LandingPageURL}}">{{.Data.DimensionName}}</a> option</li>
                                     </ul>
                                 </div>
                             {{else}}
                                 <input name="save-and-return" class="hidden" type="submit" value="Save and return"/>
                                 {{ if .Data.HasData }}
-                                    <input class="btn btn--link underline-link js-filter add-all" type="submit" value="Add all" name="add-all" id="add-all" aria-label="Add all {{.Data.DimensionName}} in this list to your saved items"/>&nbsp; &nbsp;
-									<input class="btn btn--link underline-link js-filter remove-list js-hidden" type="submit" value="Remove all" name="remove-all" id="remove-all" aria-label="Remove all {{.Data.DimensionName}} in this list from your saved items"/>
+                                    <input class="btn line-height--32 btn--link underline-link js-filter add-all" type="submit" value="Add all" name="add-all" id="add-all" aria-label="Add all {{.Data.DimensionName}} in this list to your saved items"/>&nbsp; &nbsp;
+									<input class="btn line-height--32 btn--link underline-link js-filter remove-list js-hidden" type="submit" value="Remove all" name="remove-all" id="remove-all" aria-label="Remove all {{.Data.DimensionName}} in this list from your saved items"/>
                                 {{ end }}
                                 <input name="q" type="hidden" value={{.Data.Query}}/>
                                 <div class="checkbox-group margin-top--2 padding-top--1 border-top--gallery-sm border-top--gallery-md">
@@ -96,7 +96,7 @@
                                             </div>
                                             {{ if ne .SubNum "0" }}
                                                 <div class="view-link width-md--10 float-el--right-md text-right--md padding-top--1 height-sm--5 height-md--5">
-                                                    <input name="{{ .SubURL }}" id="{{.ID}}-children" type="submit" class="padding-top--0 text-align-top btn btn--link underline-link" aria-label="{{ .Label }}: browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}" value="Browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}"/>
+                                                    <input name="{{ .SubURL }}" id="{{.ID}}-children" type="submit" class="padding-top--0 text-align-top btn line-height--32 btn--link underline-link" aria-label="{{ .Label }}: browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}" value="Browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}"/>
                                                     <div class="inline-block view-link--icon">
                                                         <span class="icon icon-arrow-right--dark-small"></span>
                                                     </div>
@@ -108,15 +108,15 @@
                             {{end}}
                         </fieldset>
                         <div class="margin-top js-hidden">
-                            <input type="submit" value="Add selected filters" class="btn btn--secondary btn--focus font-weight-700 font-size--18 line-height--32 text-wrap">
+                            <input type="submit" value="Add selected filters" class="btn line-height--32 btn--secondary btn--focus font-weight-700 line-height--32 text-wrap">
                         </div>
                         <div id="save-and-return-container" class="margin-top--5">
-                            <input name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height--32 text-wrap save-button-bottom" type="submit" value="Save and return"/>
+                            <input name="save-and-return" class="btn line-height--32 btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 line-height--32 text-wrap save-button-bottom" type="submit" value="Save and return"/>
                         </div>
                     </div>
                     <div class="col col--md-50 col--lg-20 margin-left-md--1 margin-bottom--6 margin-left-lg--4">
                         <div class="margin-bottom--6 hide--md-only hide--sm">
-                            <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height--32 text-wrap full-width save-button-right" value="Save and return"/>
+                            <input type="submit" name="save-and-return" class="btn line-height--32 btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 line-height--32 text-wrap full-width save-button-right" value="Save and return"/>
                         </div>
                         {{ template "partials/filter-selection" . }}
                     </div>

--- a/assets/templates/dataset-filter/hierarchy.tmpl
+++ b/assets/templates/dataset-filter/hierarchy.tmpl
@@ -22,14 +22,14 @@
         </div>
     </div>
 </div>
-<div class="adjust-font-size--18">
+<div class="adjust-font-size--18 line-height—32">
     <div class="page-content link-adjust">
         <div class="wrapper">
             <div class="col-wrap">
                 <div class="col col--md-50 col--lg-35 margin-left-md--1">
                     <form class="margin-bottom--2" action="{{.Data.SearchURL}}">
                         <div class="clearfix">
-                            <label for="search" class="block font-size--18 padding-bottom--2 font-weight-700">Search <span class="visuallyhidden">{{ .Data.DimensionName }}</span></label>
+                            <label for="search" class="block font-size--18 line-height—32 padding-bottom--2 font-weight-700">Search <span class="visuallyhidden">{{ .Data.DimensionName }}</span></label>
                             <input type="search" id="search" autocomplete="off" class="search__input search__input--body col col--md-31 col--lg-31" name="q" {{if .Data.IsSearchResults}} value="{{.Data.Query}}" {{end}} placeholder="Search {{.Data.DimensionName}}">
                             <button type="submit" class="search__button search__button--body col--md-3 col--lg-3" id="nav-search-submit">
                                 <span class="visuallyhidden">Search</span>
@@ -45,7 +45,7 @@
                         <fieldset>
                             <legend>
                                 {{if .Data.IsSearchResults}}
-                                    <div class="font-size--18 padding-bottom--2 margin-top--2">
+                                    <div class="font-size--18 line-height—32 padding-bottom--2 margin-top--2">
                                         <a id="back" href="{{ .Data.GoBack.URL }}">
                                             <span class="icon icon-arrow-back--dark-small"></span>Back
                                         </a>
@@ -56,7 +56,7 @@
                                         <h2 class="font-size--32 line-height--40 padding-bottom--1 font-weight-700">Browse <span class="visuallyhidden">{{ .Data.DimensionName }}</span></h2>
                                     {{end}}
                                     {{ if .Data.Parent }}
-                                        <div class="font-size--18 padding-bottom--2 margin-top--2">
+                                        <div class="font-size--18 line-height—32 padding-bottom--2 margin-top--2">
                                             <a id="back" href="{{ .Data.GoBack.URL }}">
                                                 <span class="icon icon-arrow-back--dark-small"></span>Back
                                             </a>
@@ -108,15 +108,15 @@
                             {{end}}
                         </fieldset>
                         <div class="margin-top js-hidden">
-                            <input type="submit" value="Add selected filters" class="btn btn--secondary btn--focus font-weight-700 font-size--18 text-wrap">
+                            <input type="submit" value="Add selected filters" class="btn btn--secondary btn--focus font-weight-700 font-size--18 line-height—32 text-wrap">
                         </div>
                         <div id="save-and-return-container" class="margin-top--5">
-                            <input name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 text-wrap save-button-bottom" type="submit" value="Save and return"/>
+                            <input name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height—32 text-wrap save-button-bottom" type="submit" value="Save and return"/>
                         </div>
                     </div>
                     <div class="col col--md-50 col--lg-20 margin-left-md--1 margin-bottom--6 margin-left-lg--4">
                         <div class="margin-bottom--6 hide--md-only hide--sm">
-                            <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 text-wrap full-width save-button-right" value="Save and return"/>
+                            <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height—32 text-wrap full-width save-button-right" value="Save and return"/>
                         </div>
                         {{ template "partials/filter-selection" . }}
                     </div>

--- a/assets/templates/dataset-filter/hierarchy.tmpl
+++ b/assets/templates/dataset-filter/hierarchy.tmpl
@@ -22,14 +22,14 @@
         </div>
     </div>
 </div>
-<div class="adjust-font-size--18 line-height—32">
+<div class="adjust-font-size--18 line-height--32">
     <div class="page-content link-adjust">
         <div class="wrapper">
             <div class="col-wrap">
                 <div class="col col--md-50 col--lg-35 margin-left-md--1">
                     <form class="margin-bottom--2" action="{{.Data.SearchURL}}">
                         <div class="clearfix">
-                            <label for="search" class="block font-size--18 line-height—32 padding-bottom--2 font-weight-700">Search <span class="visuallyhidden">{{ .Data.DimensionName }}</span></label>
+                            <label for="search" class="block font-size--18 line-height--32 padding-bottom--2 font-weight-700">Search <span class="visuallyhidden">{{ .Data.DimensionName }}</span></label>
                             <input type="search" id="search" autocomplete="off" class="search__input search__input--body col col--md-31 col--lg-31" name="q" {{if .Data.IsSearchResults}} value="{{.Data.Query}}" {{end}} placeholder="Search {{.Data.DimensionName}}">
                             <button type="submit" class="search__button search__button--body col--md-3 col--lg-3" id="nav-search-submit">
                                 <span class="visuallyhidden">Search</span>
@@ -45,7 +45,7 @@
                         <fieldset>
                             <legend>
                                 {{if .Data.IsSearchResults}}
-                                    <div class="font-size--18 line-height—32 padding-bottom--2 margin-top--2">
+                                    <div class="font-size--18 line-height--32 padding-bottom--2 margin-top--2">
                                         <a id="back" href="{{ .Data.GoBack.URL }}">
                                             <span class="icon icon-arrow-back--dark-small"></span>Back
                                         </a>
@@ -56,7 +56,7 @@
                                         <h2 class="font-size--32 line-height--40 padding-bottom--1 font-weight-700">Browse <span class="visuallyhidden">{{ .Data.DimensionName }}</span></h2>
                                     {{end}}
                                     {{ if .Data.Parent }}
-                                        <div class="font-size--18 line-height—32 padding-bottom--2 margin-top--2">
+                                        <div class="font-size--18 line-height--32 padding-bottom--2 margin-top--2">
                                             <a id="back" href="{{ .Data.GoBack.URL }}">
                                                 <span class="icon icon-arrow-back--dark-small"></span>Back
                                             </a>
@@ -69,9 +69,9 @@
                                 <div class="no-results-advice">
                                     <h3>Please try:</h3>
                                     <ul>
-                                        <li>Making sure that all words are spelled correctly</li>
-                                        <li>Searching again using different words</li>
-                                        <li>Check the dataset includes this <a href="{{.Data.LandingPageURL}}">{{.Data.DimensionName}}</a> option</li>
+                                        <li class="font-size--18 line-height--32">Making sure that all words are spelled correctly</li>
+                                        <li class="font-size--18 line-height--32">Searching again using different words</li>
+                                        <li class="font-size--18 line-height--32">Check the dataset includes this <a href="{{.Data.LandingPageURL}}">{{.Data.DimensionName}}</a> option</li>
                                     </ul>
                                 </div>
                             {{else}}
@@ -108,15 +108,15 @@
                             {{end}}
                         </fieldset>
                         <div class="margin-top js-hidden">
-                            <input type="submit" value="Add selected filters" class="btn btn--secondary btn--focus font-weight-700 font-size--18 line-height—32 text-wrap">
+                            <input type="submit" value="Add selected filters" class="btn btn--secondary btn--focus font-weight-700 font-size--18 line-height--32 text-wrap">
                         </div>
                         <div id="save-and-return-container" class="margin-top--5">
-                            <input name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height—32 text-wrap save-button-bottom" type="submit" value="Save and return"/>
+                            <input name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height--32 text-wrap save-button-bottom" type="submit" value="Save and return"/>
                         </div>
                     </div>
                     <div class="col col--md-50 col--lg-20 margin-left-md--1 margin-bottom--6 margin-left-lg--4">
                         <div class="margin-bottom--6 hide--md-only hide--sm">
-                            <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height—32 text-wrap full-width save-button-right" value="Save and return"/>
+                            <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height--32 text-wrap full-width save-button-right" value="Save and return"/>
                         </div>
                         {{ template "partials/filter-selection" . }}
                     </div>

--- a/assets/templates/dataset-filter/hierarchy.tmpl
+++ b/assets/templates/dataset-filter/hierarchy.tmpl
@@ -4,7 +4,7 @@
             <div class="col">
                 {{ template "partials/breadcrumb" . }}
                 <div class="col col--md-47 col--lg-39">
-                    <h1 class="page-intro__title font-weight-700">{{ .Data.DimensionName }}</h1>
+                    <h1 class="page-intro__title font-size--38 line-height--48 font-weight-700">{{ .Data.DimensionName }}</h1>
                     {{if .Metadata.Description}}
                         <div class="font-size--16">
                             <details class="margin-bottom--2 margin-bottom--2">
@@ -22,14 +22,14 @@
         </div>
     </div>
 </div>
-<div class="adjust-font-size--16">
+<div class="adjust-font-size--18">
     <div class="page-content link-adjust">
         <div class="wrapper">
             <div class="col-wrap">
                 <div class="col col--md-50 col--lg-35 margin-left-md--1">
                     <form class="margin-bottom--2" action="{{.Data.SearchURL}}">
                         <div class="clearfix">
-                            <label for="search" class="block font-size--17 padding-bottom--2 font-weight-700">Search <span class="visuallyhidden">{{ .Data.DimensionName }}</span></label>
+                            <label for="search" class="block font-size--18 padding-bottom--2 font-weight-700">Search <span class="visuallyhidden">{{ .Data.DimensionName }}</span></label>
                             <input type="search" id="search" autocomplete="off" class="search__input search__input--body col col--md-31 col--lg-31" name="q" {{if .Data.IsSearchResults}} value="{{.Data.Query}}" {{end}} placeholder="Search {{.Data.DimensionName}}">
                             <button type="submit" class="search__button search__button--body col--md-3 col--lg-3" id="nav-search-submit">
                                 <span class="visuallyhidden">Search</span>
@@ -45,7 +45,7 @@
                         <fieldset>
                             <legend>
                                 {{if .Data.IsSearchResults}}
-                                    <div class="font-size--17 padding-bottom--2 margin-top--2">
+                                    <div class="font-size--18 padding-bottom--2 margin-top--2">
                                         <a id="back" href="{{ .Data.GoBack.URL }}">
                                             <span class="icon icon-arrow-back--dark-small"></span>Back
                                         </a>
@@ -53,15 +53,15 @@
                                     <span id="search-results-info" class="padding-bottom--1 margin-top--0">{{ len .Data.FilterList }} result{{if ne (len .Data.FilterList) 1}}s{{end}} containing <strong>{{.Data.Query}}</strong>.</span>
                                 {{else}}
                                     {{if not .Data.Parent}}
-                                        <h2 class="font-size--17 padding-bottom--1 font-weight-700">Browse <span class="visuallyhidden">{{ .Data.DimensionName }}</span></h2>
+                                        <h2 class="font-size--32 line-height--40 padding-bottom--1 font-weight-700">Browse <span class="visuallyhidden">{{ .Data.DimensionName }}</span></h2>
                                     {{end}}
                                     {{ if .Data.Parent }}
-                                        <div class="font-size--17 padding-bottom--2 margin-top--2">
+                                        <div class="font-size--18 padding-bottom--2 margin-top--2">
                                             <a id="back" href="{{ .Data.GoBack.URL }}">
                                                 <span class="icon icon-arrow-back--dark-small"></span>Back
                                             </a>
                                         </div>
-                                        <h2 class="font-size--17 padding-bottom--1 font-weight-700 margin-top--0">Browse <span class="visuallyhidden">{{ .Metadata.Title }}</span></h2>
+                                        <h2 class="font-size--32 line-height--40 padding-bottom--1 font-weight-700 margin-top--0">Browse <span class="visuallyhidden">{{ .Metadata.Title }}</span></h2>
                                     {{ end }}
                                 {{end}}
                             </legend>
@@ -108,15 +108,15 @@
                             {{end}}
                         </fieldset>
                         <div class="margin-top js-hidden">
-                            <input type="submit" value="Add selected filters" class="btn btn--secondary btn--focus font-weight-700 font-size--17 text-wrap">
+                            <input type="submit" value="Add selected filters" class="btn btn--secondary btn--focus font-weight-700 font-size--18 text-wrap">
                         </div>
                         <div id="save-and-return-container" class="margin-top--5">
-                            <input name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap save-button-bottom" type="submit" value="Save and return"/>
+                            <input name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 text-wrap save-button-bottom" type="submit" value="Save and return"/>
                         </div>
                     </div>
                     <div class="col col--md-50 col--lg-20 margin-left-md--1 margin-bottom--6 margin-left-lg--4">
                         <div class="margin-bottom--6 hide--md-only hide--sm">
-                            <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap full-width save-button-right" value="Save and return"/>
+                            <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 text-wrap full-width save-button-right" value="Save and return"/>
                         </div>
                         {{ template "partials/filter-selection" . }}
                     </div>

--- a/assets/templates/dataset-filter/list-selector.tmpl
+++ b/assets/templates/dataset-filter/list-selector.tmpl
@@ -22,12 +22,12 @@
 		</div>
 	</div>
 </div>
-<div class="adjust-font-size--18 line-height—32">
+<div class="adjust-font-size--18 line-height--32">
 	<div class="page-content link-adjust">
 		<div class="wrapper">
 			<div class="col-wrap">
 				<div class="col">
-					<form id="filter-form" class="form adjust-font-size--18 line-height—32 clear-left" method="post" action="{{.Data.RangeData.URL}}">
+					<form id="filter-form" class="form adjust-font-size--18 line-height--32 clear-left" method="post" action="{{.Data.RangeData.URL}}">
 						<div class="col col--md-25 col--lg-15">
 							<div class="col col--md-29 col--lg-29">
 								<fieldset>
@@ -50,16 +50,16 @@
                                         </div>
 								</fieldset>
 								<div class="margin-top js-hidden">
-									<input type="submit" value="Add selected filters" class="btn btn--secondary btn--focus font-weight-700 font-size--18 line-height—32 text-wrap">
+									<input type="submit" value="Add selected filters" class="btn btn--secondary btn--focus font-weight-700 font-size--18 line-height--32 text-wrap">
 								</div>
 								<div id="save-and-return-container" class="margin-top--4">
-									<input name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height—32 text-wrap" type="submit" value="Save and return"/>
+									<input name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height--32 text-wrap" type="submit" value="Save and return"/>
 								</div>
 							</div>
 						</div>
 						<div id="add-all-save-and-return" class="col col--md-25 col--lg-15 margin-left-md--1 margin-bottom--6 margin-left-lg--4 js-hidden">
 							<div class="margin-bottom--6 hide--md-only hide--sm">
-								<input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18line-height—32 text-wrap full-width" value="Save and return">
+								<input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18line-height--32 text-wrap full-width" value="Save and return">
 							</div>
 						</div>
 					</form>

--- a/assets/templates/dataset-filter/list-selector.tmpl
+++ b/assets/templates/dataset-filter/list-selector.tmpl
@@ -27,16 +27,16 @@
 		<div class="wrapper">
 			<div class="col-wrap">
 				<div class="col">
-					<form id="filter-form" class="form adjust-font-size--18 line-height--32 clear-left" method="post" action="{{.Data.RangeData.URL}}">
+					<form id="filter-form" class="form clear-left line-height--32" method="post" action="{{.Data.RangeData.URL}}">
 						<div class="col col--md-25 col--lg-15">
 							<div class="col col--md-29 col--lg-29">
 								<fieldset>
 								    <legend class="visuallyhidden">{{.Data.Title}} filter options</legend>
                                         <div class="checkbox-group">
                                             <div class="checkbox margin-bottom--2">
-                                                <input name="save-and-return" class="hidden" type="submit" value="Save and return"/>
-                                                <input class="btn btn--link underline-link js-filter add-all" type="submit" value="Add all" name="add-all" aria-label="Add all items in the list to the saved items" />&nbsp; &nbsp;
-                                                <input class="btn btn--link underline-link js-filter remove-list js-hidden" type="submit" value="Remove all" id="remove-all" name="remove-all" aria-label="Remove all items in the list from the saved items" />
+                                                <input name="save-and-return" class="hidden line-height--32" type="submit" value="Save and return"/>
+                                                <input class="btn line-height--32 btn--link underline-link js-filter add-all" type="submit" value="Add all" name="add-all" aria-label="Add all items in the list to the saved items" />&nbsp; &nbsp;
+                                                <input class="btn line-height--32 btn--link underline-link js-filter remove-list js-hidden" type="submit" value="Remove all" id="remove-all" name="remove-all" aria-label="Remove all items in the list from the saved items" />
                                             </div>
                                             {{ $val := .Data.FiltersAmount }}
                                             {{ range .Data.RangeData.Values }}
@@ -50,16 +50,16 @@
                                         </div>
 								</fieldset>
 								<div class="margin-top js-hidden">
-									<input type="submit" value="Add selected filters" class="btn btn--secondary btn--focus font-weight-700 font-size--18 line-height--32 text-wrap">
+									<input type="submit" value="Add selected filters" class="btn line-height--32 btn--secondary btn--focus font-weight-700 text-wrap">
 								</div>
 								<div id="save-and-return-container" class="margin-top--4">
-									<input name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height--32 text-wrap" type="submit" value="Save and return"/>
+									<input name="save-and-return" class="btn line-height--32 btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 text-wrap" type="submit" value="Save and return"/>
 								</div>
 							</div>
 						</div>
 						<div id="add-all-save-and-return" class="col col--md-25 col--lg-15 margin-left-md--1 margin-bottom--6 margin-left-lg--4 js-hidden">
 							<div class="margin-bottom--6 hide--md-only hide--sm">
-								<input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18line-height--32 text-wrap full-width" value="Save and return">
+								<input type="submit" name="save-and-return" class="btn line-height--32 btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 text-wrap full-width" value="Save and return">
 							</div>
 						</div>
 					</form>

--- a/assets/templates/dataset-filter/list-selector.tmpl
+++ b/assets/templates/dataset-filter/list-selector.tmpl
@@ -4,7 +4,7 @@
 			<div class="col">
 				{{ template "partials/breadcrumb" . }}
 				<div class="col col--md-47 col--lg-39">
-					<h1 class="page-intro__title font-weight-700">{{.Data.Title}}</h1>
+					<h1 class="page-intro__title font-size--38 line-height--48 font-weight-700">{{.Data.Title}}</h1>
 					{{if .Metadata.Description}}
 						<div class="font-size--16">
 							<details class="margin-bottom--2 margin-bottom--2">
@@ -22,12 +22,12 @@
 		</div>
 	</div>
 </div>
-<div class="adjust-font-size--16">
+<div class="adjust-font-size--18">
 	<div class="page-content link-adjust">
 		<div class="wrapper">
 			<div class="col-wrap">
 				<div class="col">
-					<form id="filter-form" class="form adjust-font-size--16 clear-left" method="post" action="{{.Data.RangeData.URL}}">
+					<form id="filter-form" class="form adjust-font-size--18 clear-left" method="post" action="{{.Data.RangeData.URL}}">
 						<div class="col col--md-25 col--lg-15">
 							<div class="col col--md-29 col--lg-29">
 								<fieldset>
@@ -50,16 +50,16 @@
                                         </div>
 								</fieldset>
 								<div class="margin-top js-hidden">
-									<input type="submit" value="Add selected filters" class="btn btn--secondary btn--focus font-weight-700 font-size--17 text-wrap">
+									<input type="submit" value="Add selected filters" class="btn btn--secondary btn--focus font-weight-700 font-size--18 text-wrap">
 								</div>
 								<div id="save-and-return-container" class="margin-top--4">
-									<input name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap" type="submit" value="Save and return"/>
+									<input name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 text-wrap" type="submit" value="Save and return"/>
 								</div>
 							</div>
 						</div>
 						<div id="add-all-save-and-return" class="col col--md-25 col--lg-15 margin-left-md--1 margin-bottom--6 margin-left-lg--4 js-hidden">
 							<div class="margin-bottom--6 hide--md-only hide--sm">
-								<input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap full-width" value="Save and return">
+								<input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 text-wrap full-width" value="Save and return">
 							</div>
 						</div>
 					</form>

--- a/assets/templates/dataset-filter/list-selector.tmpl
+++ b/assets/templates/dataset-filter/list-selector.tmpl
@@ -22,12 +22,12 @@
 		</div>
 	</div>
 </div>
-<div class="adjust-font-size--18">
+<div class="adjust-font-size--18 line-height—32">
 	<div class="page-content link-adjust">
 		<div class="wrapper">
 			<div class="col-wrap">
 				<div class="col">
-					<form id="filter-form" class="form adjust-font-size--18 clear-left" method="post" action="{{.Data.RangeData.URL}}">
+					<form id="filter-form" class="form adjust-font-size--18 line-height—32 clear-left" method="post" action="{{.Data.RangeData.URL}}">
 						<div class="col col--md-25 col--lg-15">
 							<div class="col col--md-29 col--lg-29">
 								<fieldset>
@@ -50,16 +50,16 @@
                                         </div>
 								</fieldset>
 								<div class="margin-top js-hidden">
-									<input type="submit" value="Add selected filters" class="btn btn--secondary btn--focus font-weight-700 font-size--18 text-wrap">
+									<input type="submit" value="Add selected filters" class="btn btn--secondary btn--focus font-weight-700 font-size--18 line-height—32 text-wrap">
 								</div>
 								<div id="save-and-return-container" class="margin-top--4">
-									<input name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 text-wrap" type="submit" value="Save and return"/>
+									<input name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height—32 text-wrap" type="submit" value="Save and return"/>
 								</div>
 							</div>
 						</div>
 						<div id="add-all-save-and-return" class="col col--md-25 col--lg-15 margin-left-md--1 margin-bottom--6 margin-left-lg--4 js-hidden">
 							<div class="margin-bottom--6 hide--md-only hide--sm">
-								<input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 text-wrap full-width" value="Save and return">
+								<input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18line-height—32 text-wrap full-width" value="Save and return">
 							</div>
 						</div>
 					</form>

--- a/assets/templates/dataset-filter/preview-page.tmpl
+++ b/assets/templates/dataset-filter/preview-page.tmpl
@@ -14,7 +14,7 @@
       </div>
   </div>
 </div>
-<div id="preview-and-download" class="adjust-font-size--18 line-height—32">
+<div id="preview-and-download" class="adjust-font-size--18 line-height--32">
    <div class="page-content link-adjust">
       <div class="wrapper">
          <div class="col-wrap">
@@ -28,14 +28,14 @@
               <h2 class="font-size--32 line-height--40 font-weight-700">Preview</h2>
               <div class="table-border margin-top--3">
                 <ul class="list--neutral margin-bottom--3 margin-left">
-                  <li class="margin-top--0 margin-bottom--1"><span class="inline-block width--11">Title</span>{{.DatasetTitle}}</li>
-                  <li class="margin-top--0 margin-bottom--1"><span class="inline-block width--11">Dataset ID</span>{{.Data.DatasetID}}</li>
-                  <li class="margin-top--0 margin-bottom--1"><span class="inline-block width--11">Release date</span>{{dateFormat .ReleaseDate}}</li>
+                  <li class="font-size--18 line-height--32 margin-top--0 margin-bottom--1"><span class="inline-block width--11">Title</span>{{.DatasetTitle}}</li>
+                  <li class="font-size--18 line-height--32 margin-top--0 margin-bottom--1"><span class="inline-block width--11">Dataset ID</span>{{.Data.DatasetID}}</li>
+                  <li class="font-size--18 line-height--32 margin-top--0 margin-bottom--1"><span class="inline-block width--11">Release date</span>{{dateFormat .ReleaseDate}}</li>
                   {{if .Data.UnitOfMeasurement}}
-                    <li class="margin-top--0 margin-bottom--1"><span class="inline-block width--11">Unit of measurement</span>{{.Data.UnitOfMeasurement}}</li>
+                    <li class="font-size--18 line-height--32 margin-top--0 margin-bottom--1"><span class="inline-block width--11">Unit of measurement</span>{{.Data.UnitOfMeasurement}}</li>
                   {{end}}
                   {{range .Data.SingleValueDimensions}}
-                    <li class="margin-top--0 margin-bottom--1"><span class="inline-block width--11">{{.Name}}</span>{{ index .Values 0 }}</li>
+                    <li class="font-size--18 line-height--32 margin-top--0 margin-bottom--1"><span class="inline-block width--11">{{.Name}}</span>{{ index .Values 0 }}</li>
                   {{end}}
                 </ul>
                 <div class="table-preview">
@@ -108,7 +108,7 @@
                         {{range $i, $download := $.Data.Downloads}}
                           {{if ne $download.Extension "xls"}}
                             {{if gt (len $download.Size) 0}}
-                              <li id="{{$download.Extension}}-item" class="padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix">
+                              <li id="{{$download.Extension}}-item" class="font-size--18 line-height--32 padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix">
                                 <span class="inline-block padding-top--2">
                                   {{if eq $download.Extension "txt"}}
                                     Supporting information

--- a/assets/templates/dataset-filter/preview-page.tmpl
+++ b/assets/templates/dataset-filter/preview-page.tmpl
@@ -14,7 +14,7 @@
       </div>
   </div>
 </div>
-<div id="preview-and-download" class="adjust-font-size--18">
+<div id="preview-and-download" class="adjust-font-size--18 line-height—32">
    <div class="page-content link-adjust">
       <div class="wrapper">
          <div class="col-wrap">

--- a/assets/templates/dataset-filter/preview-page.tmpl
+++ b/assets/templates/dataset-filter/preview-page.tmpl
@@ -28,14 +28,14 @@
               <h2 class="font-size--32 line-height--40 font-weight-700">Preview</h2>
               <div class="table-border margin-top--3">
                 <ul class="list--neutral margin-bottom--3 margin-left">
-                  <li class="font-size--18 line-height--32 margin-top--0 margin-bottom--1"><span class="inline-block width--11">Title</span>{{.DatasetTitle}}</li>
-                  <li class="font-size--18 line-height--32 margin-top--0 margin-bottom--1"><span class="inline-block width--11">Dataset ID</span>{{.Data.DatasetID}}</li>
-                  <li class="font-size--18 line-height--32 margin-top--0 margin-bottom--1"><span class="inline-block width--11">Release date</span>{{dateFormat .ReleaseDate}}</li>
+                  <li class="line-height--32 margin-top--0 margin-bottom--1"><span class="inline-block width--11">Title</span>{{.DatasetTitle}}</li>
+                  <li class="line-height--32 margin-top--0 margin-bottom--1"><span class="inline-block width--11">Dataset ID</span>{{.Data.DatasetID}}</li>
+                  <li class="line-height--32 margin-top--0 margin-bottom--1"><span class="inline-block width--11">Release date</span>{{dateFormat .ReleaseDate}}</li>
                   {{if .Data.UnitOfMeasurement}}
-                    <li class="font-size--18 line-height--32 margin-top--0 margin-bottom--1"><span class="inline-block width--11">Unit of measurement</span>{{.Data.UnitOfMeasurement}}</li>
+                    <li class="line-height--32 margin-top--0 margin-bottom--1"><span class="inline-block width--11">Unit of measurement</span>{{.Data.UnitOfMeasurement}}</li>
                   {{end}}
                   {{range .Data.SingleValueDimensions}}
-                    <li class="font-size--18 line-height--32 margin-top--0 margin-bottom--1"><span class="inline-block width--11">{{.Name}}</span>{{ index .Values 0 }}</li>
+                    <li class="line-height--32 margin-top--0 margin-bottom--1"><span class="inline-block width--11">{{.Name}}</span>{{ index .Values 0 }}</li>
                   {{end}}
                 </ul>
                 <div class="table-preview">
@@ -108,7 +108,7 @@
                         {{range $i, $download := $.Data.Downloads}}
                           {{if ne $download.Extension "xls"}}
                             {{if gt (len $download.Size) 0}}
-                              <li id="{{$download.Extension}}-item" class="font-size--18 line-height--32 padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix">
+                              <li id="{{$download.Extension}}-item" class="line-height--32 padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix">
                                 <span class="inline-block padding-top--2">
                                   {{if eq $download.Extension "txt"}}
                                     Supporting information

--- a/assets/templates/dataset-filter/preview-page.tmpl
+++ b/assets/templates/dataset-filter/preview-page.tmpl
@@ -5,7 +5,7 @@
         <div class="col">
             {{ template "partials/breadcrumb" . }}
             <div class="col col--md-47 col--lg-58">
-              <h1 class="page-intro__title margin-bottom--1">
+              <h1 class="page-intro__title font-size--38 line-height--48 font-weigh-700 tmargin-bottom--1">
                 {{if not .NoDimensionData}}<span class="font-size--21 line-height--30 page-intro__type padding-top--0 padding-bottom--0">{{.DatasetTitle}}: {{.Data.Edition}}</span>{{end}}
                 <strong id="page-title">{{if not .NoDimensionData}}Filtered dataset{{else}}We can't create a preview{{end}}</strong>
               </h1>
@@ -14,7 +14,7 @@
       </div>
   </div>
 </div>
-<div id="preview-and-download" class="adjust-font-size--16">
+<div id="preview-and-download" class="adjust-font-size--18">
    <div class="page-content link-adjust">
       <div class="wrapper">
          <div class="col-wrap">
@@ -25,7 +25,7 @@
               {{ end }}
               <a id="adjust-filter-options" href="/filters/{{.Data.FilterID}}/dimensions"><span class="icon icon-arrow-back--dark-small"></span>Adjust filter options</a>
               {{ if .EnableDatasetPreview}}
-              <h2><strong>Preview</strong></h2>
+              <h2 class="font-size--32 line-height--40 font-weight-700">Preview</h2>
               <div class="table-border margin-top--3">
                 <ul class="list--neutral margin-bottom--3 margin-left">
                   <li class="margin-top--0 margin-bottom--1"><span class="inline-block width--11">Title</span>{{.DatasetTitle}}</li>
@@ -63,11 +63,11 @@
                 </div>
                </div>
                {{ end }}
-               <h2><strong>Download</strong></h2>
+               <h2 class="font-size--32 line-height--40 font-weight-700">Download</h2>
                <div class="margin-bottom--2 margin-top--2 downloads-block">
                   {{if not .IsDownloadLoaded}}
                  <div id="no-js-refresh">
-                  <h3 class="margin-bottom">Your files are being created. Please refresh the page.</h3>
+                  <h3 class="font-size--24 line-height--32 font-weight-700 margin-bottom">Your files are being created. Please refresh the page.</h3>
                   <a class="btn btn--primary btn--thick margin-bottom--4 btn--focus font-size--19" href="/filter-outputs/{{.Data.FilterOutputID}}">Refresh page</a>
                  </div>
                  {{end}}
@@ -99,7 +99,7 @@
                   <div id="other-downloads" class="{{if not .IsDownloadLoaded}}js-hidden{{end}} margin-top--2 js-show-hide show-hide show-hide--light show-hide--dark-bg border-top--iron-sm border-top--iron-md border-bottom--iron-sm border-bottom--iron-md col--lg-two-thirds col--md-two-thirds">
                     <div class="js-show-hide__title show-hide__title show-hide__title--link-style margin-top--0 margin-bottom--0 padding-right--0">
                       <button class="js-show-hide__button js-show-hide__button--slim btn--focus padding-left--1" type="button" aria-expanded="false" aria-controls="collapsible-0">
-                        <h3 class="margin-top--0 underline-link font-size--17">Other download options</h3>
+                        <h3 class="margin-top--0 underline-link font-size--24 line-height--32 font-weight-700">Other download options</h3>
                       </button>
                     </div>
                     <div class="js-show-hide__content show-hide__content padding-top--1 padding-right--1 padding-left--1">

--- a/assets/templates/dataset-filter/time.tmpl
+++ b/assets/templates/dataset-filter/time.tmpl
@@ -22,16 +22,16 @@
         </div>
     </div>
 </div>
-<div class="adjust-font-size--18">
+<div class="adjust-font-size--18 line-height—32">
     <div class="page-content link-adjust">
         <div class="wrapper">
             <div class="col col--md-47 col--lg-59">
                 <div class="col col--md-29 col--lg-29">
-                    <p class="font-size--18" id="data-available">Data available from {{.Data.FirstTime.Month}} {{.Data.FirstTime.Year}} until {{.Data.LatestTime.Month}} {{.Data.LatestTime.Year}}</p>
+                    <p class="font-size--18 line-height—32" id="data-available">Data available from {{.Data.FirstTime.Month}} {{.Data.FirstTime.Year}} until {{.Data.LatestTime.Month}} {{.Data.LatestTime.Year}}</p>
                 </div>
                 <form id="time-form" method="post" action="{{.Data.FormAction.URL}}">
                     <input name="save-and-return" class="hidden" type="submit" value="Save and return" />
-                    <div class="form adjust-font-size--18 clear-left">
+                    <div class="form adjust-font-size--18 line-height—32 clear-left">
                         <div class="col col--md-29 col--lg-29 margin-top--2">
                             <fieldset class="margin-bottom--6">
                                 <legend class="visuallyhidden">Select a method to filter the dataset by Time</legend>
@@ -176,11 +176,11 @@
                         </fieldset>
                         <div id="add-all-save-and-return" class="col col--md-25 col--lg-15 margin-top--1 margin-left--10 js-hidden">
                             <div class="margin-bottom--6 hide--md-only hide--sm">
-                                <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 text-wrap full-width" value="Save and return">
+                                <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height—32 text-wrap full-width" value="Save and return">
                             </div>
                         </div>
                         <div id="save-and-return-container" class="col--md-20 col--lg-20 width-sm--20">
-                            <input name="save-and-return" id="time-save-and-return" class="btn btn--primary btn--thick btn--big btn--focus btn--wide font-weight-700 font-size--18 margin-right--2" type="submit" value="Save and return" />
+                            <input name="save-and-return" id="time-save-and-return" class="btn btn--primary btn--thick btn--big btn--focus btn--wide font-weight-700 font-size--18 line-height—32 margin-right--2" type="submit" value="Save and return" />
                         </div>
                     </div>
             </div>

--- a/assets/templates/dataset-filter/time.tmpl
+++ b/assets/templates/dataset-filter/time.tmpl
@@ -4,7 +4,7 @@
             <div class="col">
                 {{ template "partials/breadcrumb" . }}
                 <div class="col col--md-47 col--lg-39">
-                    <h1 class="page-intro__title font-weight-700">Time</h1>
+                    <h1 class="page-intro__title font-size--38 line-height--48 font-weight-700">Time</h1>
                     {{if .Metadata.Description}}
                     <div class="font-size--16">
                         <details class="margin-bottom--2 margin-bottom--2">
@@ -22,16 +22,16 @@
         </div>
     </div>
 </div>
-<div class="adjust-font-size--16">
+<div class="adjust-font-size--18">
     <div class="page-content link-adjust">
         <div class="wrapper">
             <div class="col col--md-47 col--lg-59">
                 <div class="col col--md-29 col--lg-29">
-                    <p class="font-size--17" id="data-available">Data available from {{.Data.FirstTime.Month}} {{.Data.FirstTime.Year}} until {{.Data.LatestTime.Month}} {{.Data.LatestTime.Year}}</p>
+                    <p class="font-size--18" id="data-available">Data available from {{.Data.FirstTime.Month}} {{.Data.FirstTime.Year}} until {{.Data.LatestTime.Month}} {{.Data.LatestTime.Year}}</p>
                 </div>
                 <form id="time-form" method="post" action="{{.Data.FormAction.URL}}">
                     <input name="save-and-return" class="hidden" type="submit" value="Save and return" />
-                    <div class="form adjust-font-size--16 clear-left">
+                    <div class="form adjust-font-size--18 clear-left">
                         <div class="col col--md-29 col--lg-29 margin-top--2">
                             <fieldset class="margin-bottom--6">
                                 <legend class="visuallyhidden">Select a method to filter the dataset by Time</legend>
@@ -176,11 +176,11 @@
                         </fieldset>
                         <div id="add-all-save-and-return" class="col col--md-25 col--lg-15 margin-top--1 margin-left--10 js-hidden">
                             <div class="margin-bottom--6 hide--md-only hide--sm">
-                                <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap full-width" value="Save and return">
+                                <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 text-wrap full-width" value="Save and return">
                             </div>
                         </div>
                         <div id="save-and-return-container" class="col--md-20 col--lg-20 width-sm--20">
-                            <input name="save-and-return" id="time-save-and-return" class="btn btn--primary btn--thick btn--big btn--focus btn--wide font-weight-700 font-size--17 margin-right--2" type="submit" value="Save and return" />
+                            <input name="save-and-return" id="time-save-and-return" class="btn btn--primary btn--thick btn--big btn--focus btn--wide font-weight-700 font-size--18 margin-right--2" type="submit" value="Save and return" />
                         </div>
                     </div>
             </div>

--- a/assets/templates/dataset-filter/time.tmpl
+++ b/assets/templates/dataset-filter/time.tmpl
@@ -22,16 +22,16 @@
         </div>
     </div>
 </div>
-<div class="adjust-font-size--18 line-height—32">
+<div class="adjust-font-size--18 line-height--32">
     <div class="page-content link-adjust">
         <div class="wrapper">
             <div class="col col--md-47 col--lg-59">
                 <div class="col col--md-29 col--lg-29">
-                    <p class="font-size--18 line-height—32" id="data-available">Data available from {{.Data.FirstTime.Month}} {{.Data.FirstTime.Year}} until {{.Data.LatestTime.Month}} {{.Data.LatestTime.Year}}</p>
+                    <p class="font-size--18 line-height--32" id="data-available">Data available from {{.Data.FirstTime.Month}} {{.Data.FirstTime.Year}} until {{.Data.LatestTime.Month}} {{.Data.LatestTime.Year}}</p>
                 </div>
                 <form id="time-form" method="post" action="{{.Data.FormAction.URL}}">
                     <input name="save-and-return" class="hidden" type="submit" value="Save and return" />
-                    <div class="form adjust-font-size--18 line-height—32 clear-left">
+                    <div class="form adjust-font-size--18 line-height--32 clear-left">
                         <div class="col col--md-29 col--lg-29 margin-top--2">
                             <fieldset class="margin-bottom--6">
                                 <legend class="visuallyhidden">Select a method to filter the dataset by Time</legend>
@@ -176,11 +176,11 @@
                         </fieldset>
                         <div id="add-all-save-and-return" class="col col--md-25 col--lg-15 margin-top--1 margin-left--10 js-hidden">
                             <div class="margin-bottom--6 hide--md-only hide--sm">
-                                <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height—32 text-wrap full-width" value="Save and return">
+                                <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height--32 text-wrap full-width" value="Save and return">
                             </div>
                         </div>
                         <div id="save-and-return-container" class="col--md-20 col--lg-20 width-sm--20">
-                            <input name="save-and-return" id="time-save-and-return" class="btn btn--primary btn--thick btn--big btn--focus btn--wide font-weight-700 font-size--18 line-height—32 margin-right--2" type="submit" value="Save and return" />
+                            <input name="save-and-return" id="time-save-and-return" class="btn btn--primary btn--thick btn--big btn--focus btn--wide font-weight-700 font-size--18 line-height--32 margin-right--2" type="submit" value="Save and return" />
                         </div>
                     </div>
             </div>

--- a/assets/templates/dataset-filter/time.tmpl
+++ b/assets/templates/dataset-filter/time.tmpl
@@ -27,11 +27,11 @@
         <div class="wrapper">
             <div class="col col--md-47 col--lg-59">
                 <div class="col col--md-29 col--lg-29">
-                    <p class="font-size--18 line-height--32" id="data-available">Data available from {{.Data.FirstTime.Month}} {{.Data.FirstTime.Year}} until {{.Data.LatestTime.Month}} {{.Data.LatestTime.Year}}</p>
+                    <p class="line-height--32" id="data-available">Data available from {{.Data.FirstTime.Month}} {{.Data.FirstTime.Year}} until {{.Data.LatestTime.Month}} {{.Data.LatestTime.Year}}</p>
                 </div>
                 <form id="time-form" method="post" action="{{.Data.FormAction.URL}}">
                     <input name="save-and-return" class="hidden" type="submit" value="Save and return" />
-                    <div class="form adjust-font-size--18 line-height--32 clear-left">
+                    <div class="form line-height--32 clear-left">
                         <div class="col col--md-29 col--lg-29 margin-top--2">
                             <fieldset class="margin-bottom--6">
                                 <legend class="visuallyhidden">Select a method to filter the dataset by Time</legend>
@@ -176,11 +176,11 @@
                         </fieldset>
                         <div id="add-all-save-and-return" class="col col--md-25 col--lg-15 margin-top--1 margin-left--10 js-hidden">
                             <div class="margin-bottom--6 hide--md-only hide--sm">
-                                <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 font-size--18 line-height--32 text-wrap full-width" value="Save and return">
+                                <input type="submit" name="save-and-return" class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-right--2 font-weight-700 line-height--32 text-wrap full-width" value="Save and return">
                             </div>
                         </div>
                         <div id="save-and-return-container" class="col--md-20 col--lg-20 width-sm--20">
-                            <input name="save-and-return" id="time-save-and-return" class="btn btn--primary btn--thick btn--big btn--focus btn--wide font-weight-700 font-size--18 line-height--32 margin-right--2" type="submit" value="Save and return" />
+                            <input name="save-and-return" id="time-save-and-return" class="btn btn--primary btn--thick btn--big btn--focus btn--wide font-weight-700 line-height--32 margin-right--2" type="submit" value="Save and return" />
                         </div>
                     </div>
             </div>

--- a/assets/templates/datasetLandingPage/edition-list.tmpl
+++ b/assets/templates/datasetLandingPage/edition-list.tmpl
@@ -21,7 +21,7 @@
 
         <ul>
             {{ range .Editions}}
-                <li class="font-size--18 line-height--32 margin-top--0 margin-bottom--0"><a id="edition-{{ .Title }}" href="{{.LatestVersionURL}}">{{.Title}}</a></li>
+                <li class="line-height--32 margin-top--0 margin-bottom--0"><a id="edition-{{ .Title }}" href="{{.LatestVersionURL}}">{{.Title}}</a></li>
             {{ end }}
         </ul>
       </div>

--- a/assets/templates/datasetLandingPage/edition-list.tmpl
+++ b/assets/templates/datasetLandingPage/edition-list.tmpl
@@ -11,7 +11,7 @@
       </div>
    </div>
 </div>
-<div class="wrapper adjust-font-size--18">
+<div class="wrapper adjust-font-size--18 line-height—32">
    <div class="col-wrap padding-top--2 margin-bottom--4">
       <div class="col col--lg-two-thirds col--md-two-thirds">
         <p>{{ .Metadata.Description }}</p>

--- a/assets/templates/datasetLandingPage/edition-list.tmpl
+++ b/assets/templates/datasetLandingPage/edition-list.tmpl
@@ -3,7 +3,7 @@
       <div class="col-wrap">
          <div class="col">
             {{ template "partials/breadcrumb" . }}
-            <h1 class="page-intro__title margin-bottom--4">
+            <h1 class="page-intro__title font-size--38 line-height--48 font-weight-700 margin-bottom--4">
                <span class="page-intro__type">Editions:</span>
                {{ .Metadata.Title }}
             </h1>
@@ -11,12 +11,12 @@
       </div>
    </div>
 </div>
-<div class="wrapper adjust-font-size--16">
+<div class="wrapper adjust-font-size--18">
    <div class="col-wrap padding-top--2 margin-bottom--4">
       <div class="col col--lg-two-thirds col--md-two-thirds">
         <p>{{ .Metadata.Description }}</p>
 
-        <h2>Select an edition</h2>
+        <h2 class="font-size--32 line-height--40 font-weight-700">Select an edition</h2>
         <p class="margin-top--0">Historic data is split into annual editions to account for changes over time.</p>
 
         <ul>

--- a/assets/templates/datasetLandingPage/edition-list.tmpl
+++ b/assets/templates/datasetLandingPage/edition-list.tmpl
@@ -11,7 +11,7 @@
       </div>
    </div>
 </div>
-<div class="wrapper adjust-font-size--18 line-height—32">
+<div class="wrapper adjust-font-size--18 line-height--32">
    <div class="col-wrap padding-top--2 margin-bottom--4">
       <div class="col col--lg-two-thirds col--md-two-thirds">
         <p>{{ .Metadata.Description }}</p>
@@ -21,7 +21,7 @@
 
         <ul>
             {{ range .Editions}}
-                <li class="margin-top--0 margin-bottom--0"><a id="edition-{{ .Title }}" href="{{.LatestVersionURL}}">{{.Title}}</a></li>
+                <li class="font-size--18 line-height--32 margin-top--0 margin-bottom--0"><a id="edition-{{ .Title }}" href="{{.LatestVersionURL}}">{{.Title}}</a></li>
             {{ end }}
         </ul>
       </div>

--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -3,7 +3,7 @@
       <div class="col-wrap">
          <div class="col">
             {{ template "partials/breadcrumb" . }}
-            <h1 class="page-intro__title margin-bottom--3">
+            <h1 class="font-size--38 line-height--48 font-weight-700 page-intro__title margin-bottom--3">
                <span class="page-intro__type padding-top--0 padding-bottom--0">Dataset:</span>
                <strong>{{ .Metadata.Title }}{{ if .DatasetLandingPage.ShowEditionName }}: {{ .DatasetLandingPage.Edition }} {{ end }}</strong>
             </h1>
@@ -30,7 +30,7 @@
       </dl>
    </div>
 </div>
-<div class="wrapper adjust-font-size--16">
+<div class="wrapper adjust-font-size--18">
   <div class="col-wrap">
     <div class="col col--lg-two-thirds col--md-two-thirds margin-top--4 link-adjust">
       <section>
@@ -38,7 +38,7 @@
       </section>
       <section>
         {{$datasetID := .DatasetLandingPage.DatasetID}}{{$v := .DatasetLandingPage.Version}}
-          <h2 class="font-weight-700 margin-bottom--2">Get the data</h2>
+          <h2 class="font-size--32 line-height--40 font-weight-700 margin-bottom--2">Get the data</h2>
           <form action="/datasets/{{$datasetID}}/editions/{{$v.Edition}}/versions/{{$v.Version}}/filter" method="post">
             <input type="submit" value="Filter and download" class="btn btn--primary btn--thick margin-bottom--4 btn--focus font-weight-700">
           </form>
@@ -46,7 +46,7 @@
           <div class="margin-top--2 js-show-hide show-hide show-hide--light show-hide--dark-bg border-top--iron-sm border-top--iron-md border-bottom--iron-sm border-bottom--iron-md col--lg-two-thirds col--md-two-thirds">
             <div class="js-show-hide__title show-hide__title show-hide__title--link-style margin-top--0 margin-bottom--0 padding-right--0">
               <button class="js-show-hide__button js-show-hide__button--slim btn--focus padding-left--1" type="button" aria-expanded="false" aria-controls="collapsible-0">
-                <h3 class="margin-top--0 underline-link font-size--17">Other download options</h3>
+                <h3 class="margin-top--0 underline-link font-size—24 line-height—32 font-weight-700">Other download options</h3>
               </button>
             </div>
             <div class="js-show-hide__content show-hide__content padding-top--1 padding-right--1 padding-left--1">
@@ -70,7 +70,7 @@
          </section>
          <section>
            <div class="table-of-contents print--avoid-break border-bottom--iron-sm border-bottom--iron-md">
-             <h2 class="table-of-contents__title font-weight-700">Supporting information: table of contents</h2>
+             <h2 class="font-size--32 line-height--40 font-weight-700 table-of-contents__title font-weight-700">Supporting information: table of contents</h2>
              <ol id="toc" class="table-of-contents__list">
                <li class="table-of-contents__item margin-bottom--1 margin-left--1">
                  <a href="#id-dimensions" class="js-scroll">In this dataset</a>
@@ -108,17 +108,17 @@
            <ol class="list list--custom-numbered">
               <li>
                 <div id="id-dimensions" class="section__content--markdown margin-right--0">
-                  <h2 class="font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">In this dataset</h2>
+                  <h2 class="font-size--32 line-height--40 font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">In this dataset</h2>
                   {{if .DatasetLandingPage.UnitOfMeasurement}}
                   <div class="margin-bottom--3">
-                     <h3 class="font-size--17 font-weight-700 padding-top--0">Unit of measurement</h3>
+                     <h3 class="font-size—24 line-height—32 font-weight-700 padding-top--0">Unit of measurement</h3>
                      <p class="padding-top--0">{{.DatasetLandingPage.UnitOfMeasurement}}</p>
                   </div>
                   {{end}}
                   {{range .DatasetLandingPage.Dimensions}}
                   <div class="margin-bottom--3">
                   <div class="margin-bottom--3">
-                     <h3 class="font-size--17 font-weight-700 padding-top--0">{{.Title}}</h3>
+                     <h3 class="font-size—24 line-height—32 font-weight-700 padding-top--0">{{.Title}}</h3>
                      <ul class="dimension-values list list--pipe-seperated js-show-more-list padding-left--0">
                         {{$val_length := len .Values}}
                         {{$total_length := .TotalItems}}
@@ -145,10 +145,10 @@
              {{ if .DatasetLandingPage.LatestChanges}}
              <li>
               <div id="id-changes" class="section__content--markdown margin-right--0">
-                <h2 class="font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">What has changed in this edition</h2>
+                <h2 class="font-size--32 line-height--40 font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">What has changed in this edition</h2>
                 {{range .DatasetLandingPage.LatestChanges}}
                 <div class="margin-bottom--3">
-                   <h3 class="font-size--17 font-weight-700 padding-top--0">{{.Name}}</h3>
+                   <h3 class="font-size—24 line-height—32 font-weight-700 padding-top--0">{{.Name}}</h3>
                    <p class="padding-top--0">{{.Description}}</p>
                 </div>
                 {{ end }}
@@ -159,7 +159,7 @@
             {{if .DatasetLandingPage.QMIURL}}
             <li>
              <div id="id-qmi" class="section__content--markdown margin-right--0">
-               <h2 class="font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">Quality and methodology information</h2>
+               <h2 class="font-size--32 line-height--40 font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">Quality and methodology information</h2>
                <p class="margin-bottom--0">Includes:</p>
                <ul>
                  <li>Where the data comes from (source)</li>
@@ -175,9 +175,9 @@
             {{if .DatasetLandingPage.Methodologies}}
             <li>
              <div id="id-methodology" class="section__content--markdown margin-right--0">
-               <h2 class="font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">Methodologies</h2>
+               <h2 class="font-size--32 line-height--40 font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">Methodologies</h2>
                {{range .DatasetLandingPage.Methodologies}}
-                <h3><a href="{{.URL}}">{{.Title}}</a></h3>
+                <h3 class="font-size—24 line-height—32 font-weight-700"><a href="{{.URL}}">{{.Title}}</a></h3>
                 <p>{{.Description}}</p>
                {{end}}
                <a class="print--hide js-scroll" href="#toc">Back to table of contents</a>
@@ -187,7 +187,7 @@
             {{if .DatasetLandingPage.Citation}}
             <li>
              <div id="id-license" class="section__content--markdown margin-right--0">
-               <h2 class="font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">Usage information</h2>
+               <h2 class="font-size--32 line-height--40 font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">Usage information</h2>
                <p class="margin-bottom--0 padding-bottom--0">{{.DatasetLandingPage.Citation}}</p>
                <a class="inline-block margin-bottom--2" href="/help/termsandconditions">Terms and conditions</a><br>
                <a class="print--hide js-scroll" href="#toc">Back to table of contents</a>
@@ -197,7 +197,7 @@
             {{if .DatasetLandingPage.HasOlderVersions}}
             <li>
               <div id="id-previous" class="section__content--markdown margin-right--0">
-                 <h2 class="font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">Previous versions</h2>
+                 <h2 class="font-size--32 line-height--40 font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">Previous versions</h2>
                  <p><a href="/datasets/{{.DatasetLandingPage.DatasetID}}/editions/{{.DatasetLandingPage.Edition}}/versions">Previous versions</a> of this dataset are available.</p>
                  <a class="print--hide js-scroll" href="#toc">Back to table of contents</a>
               </div>
@@ -208,8 +208,8 @@
       </div>
       <div class="col col--lg-one-third col--md-one-third margin-top margin-bottom">
          <div class="tiles__item tiles__item--nav-type margin-left--0 margin-right--0">
-            <h3 class="tiles__title-h3 tiles__title-h3--nav">Contact details for this dataset</h3>
-            <div class="tiles__content tiles__content--nav">
+            <h3 class=" font-size—24 line-height—32 font-weight-700 tiles__title-h3 tiles__title-h3--nav">Contact details for this dataset</h3>
+            <div class="tiles__content tiles__content--nav wrapper adjust-font-size--14">
                <address>
                   {{ if .ContactDetails.Name}}
                   <span class="contact-name block">{{ .ContactDetails.Name }}</span>
@@ -225,7 +225,7 @@
          </div>
          {{ if .DatasetLandingPage.Publications }}
          <div class="tiles__item tiles__item--nav-type margin-left--0 margin-right--0">
-            <h3 class="tiles__title-h3 tiles__title-h3--nav">Publications that use this data</h3>
+            <h3 class="font-size—24 line-height—32 font-weight-700 tiles__title-h3 tiles__title-h3--nav">Publications that use this data</h3>
             <div class="tiles__content tiles__content--nav">
                <ul class="list--neutral">
                   {{ range .DatasetLandingPage.Publications }}
@@ -237,7 +237,7 @@
          {{ end }}
          {{ if .DatasetLandingPage.RelatedLinks }}
          <div class="tiles__item tiles__item--nav-type margin-left--0 margin-right--0">
-            <h3 class="tiles__title-h3 tiles__title-h3--nav">Related datasets</h3>
+            <h3 class="font-size—24 line-height—32 font-weight-700 tiles__title-h3 tiles__title-h3--nav">Related datasets</h3>
             <div class="tiles__content tiles__content--nav">
                <ul class="list--neutral">
                   {{ range .DatasetLandingPage.RelatedLinks }}
@@ -249,7 +249,7 @@
          {{ end }}
          {{ if .DatasetLandingPage.IsNationalStatistic }}
          <div class="tiles__item tiles__item--nav-type margin-left--0 margin-right--0">
-            <h3 class="tiles__title-h3 tiles__title-h3--nav"><img class="meta__image" src="/img/national-statistics.png" alt="National Statistics logo"><div class="padding-top--1 padding-bottom--1">National Statistic</div></h3>
+            <h3 class="font-size—24 line-height—32 font-weight-700 tiles__title-h3 tiles__title-h3--nav"><img class="meta__image" src="/img/national-statistics.png" alt="National Statistics logo"><div class="padding-top--1 padding-bottom--1">National Statistic</div></h3>
             <div class="tiles__content tiles__content--nav">
                <p class="margin-bottom--0">
                   Certified by the UK Statistics Authority as compliant with the Code of Practice for Official Statistics.

--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -40,7 +40,7 @@
         {{$datasetID := .DatasetLandingPage.DatasetID}}{{$v := .DatasetLandingPage.Version}}
           <h2 class="font-size--32 line-height--40 font-weight-700 margin-bottom--2">Get the data</h2>
           <form action="/datasets/{{$datasetID}}/editions/{{$v.Edition}}/versions/{{$v.Version}}/filter" method="post">
-            <input type="submit" value="Filter and download" class="btn btn--primary btn--thick margin-bottom--4 btn--focus line-heigh--32 font-weight-700">
+            <input type="submit" value="Filter and download" class="btn btn--primary btn--thick margin-bottom--4 btn--focus line-height--32 font-weight-700">
           </form>
           {{ if gt (len $v.Downloads) 0}}
           <div class="margin-top--2 js-show-hide show-hide show-hide--light show-hide--dark-bg border-top--iron-sm border-top--iron-md border-bottom--iron-sm border-bottom--iron-md col--lg-two-thirds col--md-two-thirds">
@@ -53,9 +53,9 @@
               <div class="margin-bottom--2">
                 <ul class="list--neutral">
                 {{range $i, $download := $v.Downloads}}
-                {{if gt (len $download.Size) 0}}{{if gt (len $download.Size) 0}}<li class="font-size--18 line-height--32 padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix"><span class="inline-block padding-top--2">{{if eq $download.Extension "txt"}}Supporting information{{else}}Complete dataset (<span class="uppercase">{{$download.Extension}}</span> format){{end}}</span>
+                {{if gt (len $download.Size) 0}}{{if gt (len $download.Size) 0}}<li class="line-height--32 padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix"><span class="inline-block padding-top--2">{{if eq $download.Extension "txt"}}Supporting information{{else}}Complete dataset (<span class="uppercase">{{$download.Extension}}</span> format){{end}}</span>
                   <div class="width--12 inline-block float-right float-el--left-sm text-left--sm"><a id="{{$download.Extension}}-download"                                     data-gtm-download-file="{{$download.URI}}"
-                  data-gtm-download-type="{{$download.Extension}}" class="btn btn--primary margin-top--1 margin-bottom--1 margin-right--half width--11" href="{{$download.URI}}"><strong>{{$download.Extension}}</strong> ({{humanSize $download.Size}})</a></div></li>{{end}}{{end}}
+                  data-gtm-download-type="{{$download.Extension}}" class="btn line-height--32 btn--primary margin-top--1 margin-bottom--1 margin-right--half width--11" href="{{$download.URI}}"><strong>{{$download.Extension}}</strong> ({{humanSize $download.Size}})</a></div></li>{{end}}{{end}}
                 {{end}}
                 </ul>
               </div>
@@ -123,7 +123,7 @@
                         {{$val_length := len .Values}}
                         {{$total_length := .TotalItems}}
                         {{$vals := .Values}}{{range $i, $v := $vals}}
-                        <li class="font-size--18 line-height--32">{{.}}</li>
+                        <li class="line-height--32">{{.}}</li>
                         {{end}}
                      </ul>
                      {{if gt $val_length 9}}
@@ -229,7 +229,7 @@
             <div class="tiles__content tiles__content--nav">
                <ul class="list--neutral">
                   {{ range .DatasetLandingPage.Publications }}
-                  <li class="font-size--18 line-height--32"><a href="{{ .URL }}">{{ .Title }}</a></li>
+                  <li class="line-height--32"><a href="{{ .URL }}">{{ .Title }}</a></li>
                   {{ end }}
                </ul>
             </div>
@@ -241,7 +241,7 @@
             <div class="tiles__content tiles__content--nav">
                <ul class="list--neutral">
                   {{ range .DatasetLandingPage.RelatedLinks }}
-                  <li class="font-size--18 line-height--32"><a href="{{ .URL }}">{{ .Title }}</a></li>
+                  <li class="line-height--32"><a href="{{ .URL }}">{{ .Title }}</a></li>
                   {{ end }}
                </ul>
             </div>

--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -30,7 +30,7 @@
       </dl>
    </div>
 </div>
-<div class="wrapper adjust-font-size--18 line-height—32">
+<div class="wrapper adjust-font-size--18 line-height--32">
   <div class="col-wrap">
     <div class="col col--lg-two-thirds col--md-two-thirds margin-top--4 link-adjust">
       <section>
@@ -46,14 +46,14 @@
           <div class="margin-top--2 js-show-hide show-hide show-hide--light show-hide--dark-bg border-top--iron-sm border-top--iron-md border-bottom--iron-sm border-bottom--iron-md col--lg-two-thirds col--md-two-thirds">
             <div class="js-show-hide__title show-hide__title show-hide__title--link-style margin-top--0 margin-bottom--0 padding-right--0">
               <button class="js-show-hide__button js-show-hide__button--slim btn--focus padding-left--1" type="button" aria-expanded="false" aria-controls="collapsible-0">
-                <h3 class="margin-top--0 underline-link font-size—24 line-height—32 font-weight-700">Other download options</h3>
+                <h3 class="margin-top--0 underline-link font-size--24 line-height--32 font-weight-700">Other download options</h3>
               </button>
             </div>
             <div class="js-show-hide__content show-hide__content padding-top--1 padding-right--1 padding-left--1">
               <div class="margin-bottom--2">
                 <ul class="list--neutral">
                 {{range $i, $download := $v.Downloads}}
-                {{if gt (len $download.Size) 0}}{{if gt (len $download.Size) 0}}<li class="padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix"><span class="inline-block padding-top--2">{{if eq $download.Extension "txt"}}Supporting information{{else}}Complete dataset (<span class="uppercase">{{$download.Extension}}</span> format){{end}}</span>
+                {{if gt (len $download.Size) 0}}{{if gt (len $download.Size) 0}}<li class="font-size--18 line-height--32 padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix"><span class="inline-block padding-top--2">{{if eq $download.Extension "txt"}}Supporting information{{else}}Complete dataset (<span class="uppercase">{{$download.Extension}}</span> format){{end}}</span>
                   <div class="width--12 inline-block float-right float-el--left-sm text-left--sm"><a id="{{$download.Extension}}-download"                                     data-gtm-download-file="{{$download.URI}}"
                   data-gtm-download-type="{{$download.Extension}}" class="btn btn--primary margin-top--1 margin-bottom--1 margin-right--half width--11" href="{{$download.URI}}"><strong>{{$download.Extension}}</strong> ({{humanSize $download.Size}})</a></div></li>{{end}}{{end}}
                 {{end}}
@@ -72,31 +72,31 @@
            <div class="table-of-contents print--avoid-break border-bottom--iron-sm border-bottom--iron-md">
              <h2 class="font-size--32 line-height--40 font-weight-700 table-of-contents__title font-weight-700">Supporting information: table of contents</h2>
              <ol id="toc" class="table-of-contents__list">
-               <li class="table-of-contents__item margin-bottom--1 margin-left--1">
+               <li class="line-height--32 table-of-contents__item margin-bottom--1 margin-left--1">
                  <a href="#id-dimensions" class="js-scroll">In this dataset</a>
                </li>
                {{if .DatasetLandingPage.LatestChanges}}
-               <li class="table-of-contents__item margin-bottom--1 margin-left--1">
+               <li class="line-height--32 table-of-contents__item margin-bottom--1 margin-left--1">
                  <a href="#id-changes" class="js-scroll">What has changed in this edition</a>
                </li>
                {{end}}
                {{if .DatasetLandingPage.QMIURL}}
-               <li class="table-of-contents__item margin-bottom--1 margin-left--1">
+               <li class="line-height--32 table-of-contents__item margin-bottom--1 margin-left--1">
                  <a href="#id-qmi" class="js-scroll">Quality and methodology information</a>
                </li>
                {{end}}
                {{if .DatasetLandingPage.Methodologies}}
-               <li class="table-of-contents__item margin-bottom--1 margin-left--1">
+               <li class="line-height--32 table-of-contents__item margin-bottom--1 margin-left--1">
                  <a href="#id-methodology" class="js-scroll">Methodologies</a>
                </li>
                {{end}}
                {{if .DatasetLandingPage.Citation}}
-               <li class="table-of-contents__item margin-bottom--1 margin-left--1">
+               <li class="line-height--32 table-of-contents__item margin-bottom--1 margin-left--1">
                  <a href="#id-license" class="js-scroll">Usage information</a>
                </li>
                {{end}}
                {{if .DatasetLandingPage.HasOlderVersions}}
-               <li class="table-of-contents__item margin-bottom--1 margin-left--1">
+               <li class="line-height--32 table-of-contents__item margin-bottom--1 margin-left--1">
                  <a href="#id-previous" class="js-scroll">Previous versions</a>
                </li>
                {{end}}
@@ -111,19 +111,19 @@
                   <h2 class="font-size--32 line-height--40 font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">In this dataset</h2>
                   {{if .DatasetLandingPage.UnitOfMeasurement}}
                   <div class="margin-bottom--3">
-                     <h3 class="font-size—24 line-height—32 font-weight-700 padding-top--0">Unit of measurement</h3>
+                     <h3 class="font-size--24 line-height--32 font-weight-700 padding-top--0">Unit of measurement</h3>
                      <p class="padding-top--0">{{.DatasetLandingPage.UnitOfMeasurement}}</p>
                   </div>
                   {{end}}
                   {{range .DatasetLandingPage.Dimensions}}
                   <div class="margin-bottom--3">
                   <div class="margin-bottom--3">
-                     <h3 class="font-size—24 line-height—32 font-weight-700 padding-top--0">{{.Title}}</h3>
+                     <h3 class="font-size--24 line-height--32 font-weight-700 padding-top--0">{{.Title}}</h3>
                      <ul class="dimension-values list list--pipe-seperated js-show-more-list padding-left--0">
                         {{$val_length := len .Values}}
                         {{$total_length := .TotalItems}}
                         {{$vals := .Values}}{{range $i, $v := $vals}}
-                        <li>{{.}}</li>
+                        <li class="font-size--18 line-height--32">{{.}}</li>
                         {{end}}
                      </ul>
                      {{if gt $val_length 9}}
@@ -148,7 +148,7 @@
                 <h2 class="font-size--32 line-height--40 font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">What has changed in this edition</h2>
                 {{range .DatasetLandingPage.LatestChanges}}
                 <div class="margin-bottom--3">
-                   <h3 class="font-size—24 line-height—32 font-weight-700 padding-top--0">{{.Name}}</h3>
+                   <h3 class="font-size--24 line-height--32 font-weight-700 padding-top--0">{{.Name}}</h3>
                    <p class="padding-top--0">{{.Description}}</p>
                 </div>
                 {{ end }}
@@ -162,10 +162,10 @@
                <h2 class="font-size--32 line-height--40 font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">Quality and methodology information</h2>
                <p class="margin-bottom--0">Includes:</p>
                <ul>
-                 <li>Where the data comes from (source)</li>
-                 <li>The accuracy and reliability of the data</li>
-                 <li>The relevance of the data to certain applications or uses</li>
-                 <li>Things to consider when using the data</li>
+                 <li class="font-size--18 line-height--32">Where the data comes from (source)</li>
+                 <li class="font-size--18 line-height--32">The accuracy and reliability of the data</li>
+                 <li class="font-size--18 line-height--32">The relevance of the data to certain applications or uses</li>
+                 <li class="font-size--18 line-height--32">Things to consider when using the data</li>
                </ul>
                <p>Read the full <a href="{{.DatasetLandingPage.QMIURL}}">Quality and methodology information (QMI)</a> for this dataset.</p>
                <a class="print--hide js-scroll" href="#toc">Back to table of contents</a>
@@ -177,7 +177,7 @@
              <div id="id-methodology" class="section__content--markdown margin-right--0">
                <h2 class="font-size--32 line-height--40 font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">Methodologies</h2>
                {{range .DatasetLandingPage.Methodologies}}
-                <h3 class="font-size—24 line-height—32 font-weight-700"><a href="{{.URL}}">{{.Title}}</a></h3>
+                <h3 class="font-size--24 line-height--32 font-weight-700"><a href="{{.URL}}">{{.Title}}</a></h3>
                 <p>{{.Description}}</p>
                {{end}}
                <a class="print--hide js-scroll" href="#toc">Back to table of contents</a>
@@ -208,7 +208,7 @@
       </div>
       <div class="col col--lg-one-third col--md-one-third margin-top margin-bottom">
          <div class="tiles__item tiles__item--nav-type margin-left--0 margin-right--0">
-            <h3 class=" font-size—24 line-height—32 font-weight-700 tiles__title-h3 tiles__title-h3--nav">Contact details for this dataset</h3>
+            <h3 class="font-size--24 line-height--32 font-weight-700 tiles__title-h3 tiles__title-h3--nav">Contact details for this dataset</h3>
             <div class="tiles__content tiles__content--nav wrapper adjust-font-size--14">
                <address>
                   {{ if .ContactDetails.Name}}
@@ -225,11 +225,11 @@
          </div>
          {{ if .DatasetLandingPage.Publications }}
          <div class="tiles__item tiles__item--nav-type margin-left--0 margin-right--0">
-            <h3 class="font-size—24 line-height—32 font-weight-700 tiles__title-h3 tiles__title-h3--nav">Publications that use this data</h3>
+            <h3 class="font-size--24 line-height--32 font-weight-700 tiles__title-h3 tiles__title-h3--nav">Publications that use this data</h3>
             <div class="tiles__content tiles__content--nav">
                <ul class="list--neutral">
                   {{ range .DatasetLandingPage.Publications }}
-                  <li><a href="{{ .URL }}">{{ .Title }}</a></li>
+                  <li class="font-size--18 line-height--32"><a href="{{ .URL }}">{{ .Title }}</a></li>
                   {{ end }}
                </ul>
             </div>
@@ -237,11 +237,11 @@
          {{ end }}
          {{ if .DatasetLandingPage.RelatedLinks }}
          <div class="tiles__item tiles__item--nav-type margin-left--0 margin-right--0">
-            <h3 class="font-size—24 line-height—32 font-weight-700 tiles__title-h3 tiles__title-h3--nav">Related datasets</h3>
+            <h3 class="font-size--24 line-height--32 font-weight-700 tiles__title-h3 tiles__title-h3--nav">Related datasets</h3>
             <div class="tiles__content tiles__content--nav">
                <ul class="list--neutral">
                   {{ range .DatasetLandingPage.RelatedLinks }}
-                  <li><a href="{{ .URL }}">{{ .Title }}</a></li>
+                  <li class="font-size--18 line-height--32"><a href="{{ .URL }}">{{ .Title }}</a></li>
                   {{ end }}
                </ul>
             </div>
@@ -249,7 +249,7 @@
          {{ end }}
          {{ if .DatasetLandingPage.IsNationalStatistic }}
          <div class="tiles__item tiles__item--nav-type margin-left--0 margin-right--0">
-            <h3 class="font-size—24 line-height—32 font-weight-700 tiles__title-h3 tiles__title-h3--nav"><img class="meta__image" src="/img/national-statistics.png" alt="National Statistics logo"><div class="padding-top--1 padding-bottom--1">National Statistic</div></h3>
+            <h3 class="font-size--24 line-height--32 font-weight-700 tiles__title-h3 tiles__title-h3--nav"><img class="meta__image" src="/img/national-statistics.png" alt="National Statistics logo"><div class="padding-top--1 padding-bottom--1">National Statistic</div></h3>
             <div class="tiles__content tiles__content--nav">
                <p class="margin-bottom--0">
                   Certified by the UK Statistics Authority as compliant with the Code of Practice for Official Statistics.

--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -162,10 +162,10 @@
                <h2 class="font-size--32 line-height--40 font-weight-700 padding-top--0 padding-left-sm--2 padding-left-md--3">Quality and methodology information</h2>
                <p class="margin-bottom--0">Includes:</p>
                <ul>
-                 <li class="font-size--18 line-height--32">Where the data comes from (source)</li>
-                 <li class="font-size--18 line-height--32">The accuracy and reliability of the data</li>
-                 <li class="font-size--18 line-height--32">The relevance of the data to certain applications or uses</li>
-                 <li class="font-size--18 line-height--32">Things to consider when using the data</li>
+                 <li class="line-height--32">Where the data comes from (source)</li>
+                 <li class="line-height--32">The accuracy and reliability of the data</li>
+                 <li class="line-height--32">The relevance of the data to certain applications or uses</li>
+                 <li class="line-height--32">Things to consider when using the data</li>
                </ul>
                <p>Read the full <a href="{{.DatasetLandingPage.QMIURL}}">Quality and methodology information (QMI)</a> for this dataset.</p>
                <a class="print--hide js-scroll" href="#toc">Back to table of contents</a>

--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -30,7 +30,7 @@
       </dl>
    </div>
 </div>
-<div class="wrapper adjust-font-size--18">
+<div class="wrapper adjust-font-size--18 line-height—32">
   <div class="col-wrap">
     <div class="col col--lg-two-thirds col--md-two-thirds margin-top--4 link-adjust">
       <section>

--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -40,7 +40,7 @@
         {{$datasetID := .DatasetLandingPage.DatasetID}}{{$v := .DatasetLandingPage.Version}}
           <h2 class="font-size--32 line-height--40 font-weight-700 margin-bottom--2">Get the data</h2>
           <form action="/datasets/{{$datasetID}}/editions/{{$v.Edition}}/versions/{{$v.Version}}/filter" method="post">
-            <input type="submit" value="Filter and download" class="btn btn--primary btn--thick margin-bottom--4 btn--focus font-weight-700">
+            <input type="submit" value="Filter and download" class="btn btn--primary btn--thick margin-bottom--4 btn--focus line-heigh--32 font-weight-700">
           </form>
           {{ if gt (len $v.Downloads) 0}}
           <div class="margin-top--2 js-show-hide show-hide show-hide--light show-hide--dark-bg border-top--iron-sm border-top--iron-md border-bottom--iron-sm border-bottom--iron-md col--lg-two-thirds col--md-two-thirds">

--- a/assets/templates/datasetLandingPage/version-list.tmpl
+++ b/assets/templates/datasetLandingPage/version-list.tmpl
@@ -3,18 +3,18 @@
       <div class="col-wrap">
          <div class="col">
             {{ template "partials/breadcrumb" . }}
-            <h1 class="page-intro__title margin-bottom--4">
+            <h1 class="page-intro__title font-size--38 line-height--48 font-weight-700 margin-bottom--4">
                <strong>{{ .Metadata.Title }}</strong>
             </h1>
          </div>
       </div>
    </div>
 </div>
-<div class="wrapper adjust-font-size--16 link-adjust">
+<div class="wrapper adjust-font-size--18 link-adjust">
    <div class="col-wrap padding-top--2 margin-bottom--4">
       <div class="col">
          {{ range $i, $version := $.Data.Versions }}
-            <a href="{{ .VersionURL }}"><h2 class="margin-bottom--1 font-weight-700">{{ dateFormat .Date }}{{ if .IsLatest }} (latest){{ end }}</h2></a>
+            <a href="{{ .VersionURL }}"><h2 class="margin-bottom--1 font-size--32 line-height--40 font-weight-700">{{ dateFormat .Date }}{{ if .IsLatest }} (latest){{ end }}</h2></a>
                <p class="margin-top--0 margin-bottom--0 padding-top--0 padding-bottom--0">
                   Version: {{ .VersionNumber }}
                </p>
@@ -35,7 +35,7 @@
                         <div class="panel padding-top--1 padding-bottom--1 margin-bottom-2">
                         {{ if .Corrections }}
                            {{ range $i, $correction := .Corrections }}
-                              <h3 class="margin-top--1 margin-bottom--2 padding-top--0 padding-bottom--0 font-weight-700">
+                              <h3 class="margin-top--1 margin-bottom--2 padding-top--0 padding-bottom--0 font-size—24 line-height—32 font-weight-700">
                                  Correction: {{ dateFormat .Date }}
                               </h3>
                               <p class="margin-top--0 margin-bottom--2">{{ .Reason }}</p>

--- a/assets/templates/datasetLandingPage/version-list.tmpl
+++ b/assets/templates/datasetLandingPage/version-list.tmpl
@@ -23,7 +23,7 @@
                </p>
                   <ul class="margin-top--0 padding-left--2">
                      {{ range .Downloads }}
-                        <li class="font-size--18 line-height--32 margin-top--0 margin-bottom--0 padding-top--0 padding-bottom--0">
+                        <li class="line-height--32 margin-top--0 margin-bottom--0 padding-top--0 padding-bottom--0">
                            <a href="{{ .URI }}">{{ .Extension }} {{ humanSize .Size }}</a>
                         </li>
                      {{ end }}

--- a/assets/templates/datasetLandingPage/version-list.tmpl
+++ b/assets/templates/datasetLandingPage/version-list.tmpl
@@ -10,7 +10,7 @@
       </div>
    </div>
 </div>
-<div class="wrapper adjust-font-size--18 line-height—32 link-adjust">
+<div class="wrapper adjust-font-size--18 line-height--32 link-adjust">
    <div class="col-wrap padding-top--2 margin-bottom--4">
       <div class="col">
          {{ range $i, $version := $.Data.Versions }}
@@ -22,7 +22,7 @@
                   <strong>Downloads:</strong>
                   <ul class="margin-top--0 padding-left--2">
                      {{ range .Downloads }}
-                        <li class="margin-top--0 margin-bottom--0 padding-top--0 padding-bottom--0">
+                        <li class="font-size--18 line-height--32 margin-top--0 margin-bottom--0 padding-top--0 padding-bottom--0">
                            <a href="{{ .URI }}">{{ .Extension }} {{ humanSize .Size }}</a>
                         </li>
                      {{ end }}
@@ -35,7 +35,7 @@
                         <div class="panel padding-top--1 padding-bottom--1 margin-bottom-2">
                         {{ if .Corrections }}
                            {{ range $i, $correction := .Corrections }}
-                              <h3 class="margin-top--1 margin-bottom--2 padding-top--0 padding-bottom--0 font-size—24 line-height—32 font-weight-700">
+                              <h3 class="margin-top--1 margin-bottom--2 padding-top--0 padding-bottom--0 font-size--24 line-height--32 font-weight-700">
                                  Correction: {{ dateFormat .Date }}
                               </h3>
                               <p class="margin-top--0 margin-bottom--2">{{ .Reason }}</p>

--- a/assets/templates/datasetLandingPage/version-list.tmpl
+++ b/assets/templates/datasetLandingPage/version-list.tmpl
@@ -10,7 +10,7 @@
       </div>
    </div>
 </div>
-<div class="wrapper adjust-font-size--18 link-adjust">
+<div class="wrapper adjust-font-size--18 line-height—32 link-adjust">
    <div class="col-wrap padding-top--2 margin-bottom--4">
       <div class="col">
          {{ range $i, $version := $.Data.Versions }}

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/e77558a"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/be61a32"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What

On all CMD templates pages the following has been updated
change all font-size(16,17) to 18 and line-height to 32
all h1 to===>font-size to 38 and line-height to 48
all h2 to===> font-size to 32 and line-height to 40
all h3 to===>font-size to 24 and line height to 32
Updated changes in sixteen repo is required when viewing the CMD pages
Update necessary <li> font size to 18  and line-height 32

### How to review

Check all changes are correct as per ticket
https://trello.com/c/ImaXOlpP/119-typography-on-cmd-pages-is-incorrect-too-small-s4-1-day
Run the CMD journey and check for the changes
Note: https://github.com/ONSdigital/sixteens/pull/256  is required to see the changes in this PR

### Who can review
Anyone