### PR TITLE
decrease margin size

### DIFF
--- a/assets/templates/partials/banners/covid.tmpl
+++ b/assets/templates/partials/banners/covid.tmpl
@@ -1,4 +1,4 @@
-<section class="background--pineapple-yellow wrapper banner__bottom-shadow margin-top-sm--7 margin-top-md--5 margin-top-lg--3 margin-bottom--3 js-hover-click">
+<section class="background--pineapple-yellow wrapper banner__bottom-shadow margin-top-sm--3 margin-top-md--3 margin-top-lg--3 margin-bottom--3 js-hover-click">
     <div class="col-wrap">
         <a href="/peoplepopulationandcommunity/healthandsocialcare/conditionsanddiseases">
             <div class="col">


### PR DESCRIPTION
### What

The only change made was to decrease the margin size. It appears other changes to css in sixteens has corrected the banner from covering the menu. 

### How to review

Look at the homepage and see a large gap between top of banner and bottom of menu on small and medium screens. Inspect page to see that the margin on top is 7 and 5 respectively. Pull this branch and inspect page to see top margin is now 3. 

### Who can review

Anyone but me. 