### PR TITLE
Updated styling for hierarchy options

### DIFF
--- a/assets/templates/dataset-filter/hierarchy.tmpl
+++ b/assets/templates/dataset-filter/hierarchy.tmpl
@@ -96,7 +96,7 @@
                                             </div>
                                             {{ if ne .SubNum "0" }}
                                                 <div class="view-link width-md--11 float-el--right-md text-right--md padding-top--1 height-sm--5 height-md--5">
-                                                    <input name="{{ .SubURL }}" id="{{.ID}}-children" type="submit" class="padding-top--0 text-align-top btn btn--link underline-link" aria-label="{{ .Label }}: browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}" value="Browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}"/>
+                                                    <input name="{{ .SubURL }}" id="{{.ID}}-children" type="submit" class="padding-top--0 text-align-top btn line-height--32 btn--link underline-link" aria-label="{{ .Label }}: browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}" value="Browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}"/>
                                                     <div class="inline-block view-link--icon">
                                                         <span class="icon icon-arrow-right--dark-small"></span>
                                                     </div>

--- a/assets/templates/dataset-filter/hierarchy.tmpl
+++ b/assets/templates/dataset-filter/hierarchy.tmpl
@@ -84,7 +84,7 @@
                                 <div class="checkbox-group margin-top--2 padding-top--1 border-top--gallery-sm border-top--gallery-md">
                                     {{ range $i, $v := .Data.FilterList }}
                                         <div class="checkbox hierarchy-box border-bottom--gallery-sm border-bottom--gallery-md margin-bottom--1 clearfix">
-                                            <div class="{{ if ne .SubNum "0" }}width-md--25{{else}}width-md--35{{end}} float-el--left-md">
+                                            <div class="{{ if ne .SubNum "0" }}width-md--24{{else}}width-md--35{{end}} float-el--left-md">
                                                 {{if .HasData}}
                                                     <input type="checkbox" class="checkbox__input js-filter{{if .Selected}} checked{{end}}" id="id-{{$i}}" name="{{.ID}}" {{if .Selected}}checked{{end}}>
                                                     <label id="{{.ID}}" class="checkbox__label" for="id-{{$i}}">
@@ -95,8 +95,8 @@
                                                 {{end}}
                                             </div>
                                             {{ if ne .SubNum "0" }}
-                                                <div class="view-link width-md--10 float-el--right-md text-right--md padding-top--1 height-sm--5 height-md--5">
-                                                    <input name="{{ .SubURL }}" id="{{.ID}}-children" type="submit" class="padding-top--0 text-align-top btn line-height--32 btn--link underline-link" aria-label="{{ .Label }}: browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}" value="Browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}"/>
+                                                <div class="view-link width-md--11 float-el--right-md text-right--md padding-top--1 height-sm--5 height-md--5">
+                                                    <input name="{{ .SubURL }}" id="{{.ID}}-children" type="submit" class="padding-top--0 text-align-top btn btn--link underline-link" aria-label="{{ .Label }}: browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}" value="Browse {{.SubNum}} {{$.Type}}{{ if ne .SubNum "1" }}s{{end}}"/>
                                                     <div class="inline-block view-link--icon">
                                                         <span class="icon icon-arrow-right--dark-small"></span>
                                                     </div>


### PR DESCRIPTION
### What

Fixed an issue where the 'browse by x type' text in hierarchy options overflows when it's a number greater than 9, specifically by increasing the width of the 'browse by' element:

**Before**
![image](https://user-images.githubusercontent.com/23668262/104167003-8a74c980-53f3-11eb-96fe-840ebdee7f27.png)

**After**
![image](https://user-images.githubusercontent.com/23668262/104167221-ea6b7000-53f3-11eb-9359-22f11ec31fad.png)

### How to review

Sense check. Go to a hierarchy filter page and seeing that the styles look okay

Make sure no other changes present

### Who can review

Anyone