### PR TITLE
Update Sixteens version

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/9b00fae"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/b089aa4"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What

Update Sixteens to newest version. This fixes the bug in the CMD filter journey where checkbox interactions make a call to the `remove-all` endpoint instead of `update` after the user clicks "Remove All" to clear their basket. This was due to a bug in the JS enhancement in Sixteens where the request URL was not being properly updated.

### How to review

Sense check that the latest Sixteens version is being used

### Who can review

Anyone
