### PR TITLE
add search pagination

### DIFF
--- a/assets/templates/search.tmpl
+++ b/assets/templates/search.tmpl
@@ -8,6 +8,7 @@
             {{ template "search/filter" . }}
             <section class="col col--md-34 col--lg-40 margin-left-md--1" aria-label="Search results">
                 {{ template "search/results" . }}
+                {{ template "search/pagination" . }}
             </section>
         </div>
     </div>

--- a/assets/templates/search/pagination.tmpl
+++ b/assets/templates/search/pagination.tmpl
@@ -44,5 +44,4 @@
             <button class="btn btn--primary btn--thin btn--small hide--md" type="submit">Submit</button>
         </div>
     </div>
-    <input type="hidden" name="page" value={{ $pagination.CurrentPage}} class="js-auto-submit__input">
 </form>

--- a/assets/templates/search/pagination.tmpl
+++ b/assets/templates/search/pagination.tmpl
@@ -1,47 +1,51 @@
 {{ $pagination := .Data.Pagination }}
 <form id="js-pagination-container" class="js-auto-submit__form">
     <div class="col col--md-22 col--lg-28">
-        <nav aria-label="Pagination breadcrumbs">
-            <ul class="list--neutral list--inline margin-right-sm--1 margin-right-md--1 margin-bottom-sm--7 margin-bottom-md--7">
-                {{ $prevURL := "" }}
-                {{ $nextURL := "" }}
-                {{ range $pagination.PagesToDisplay }}
-                    {{ if eq .PageNumber (subtract $pagination.CurrentPage 1 ) }}{{ $prevURL = .URL }}{{end}}
-                    {{ if eq .PageNumber (add $pagination.CurrentPage 1 ) }}{{ $nextURL = .URL }}{{end}}
-                {{ end }}
-                {{ if gt $pagination.CurrentPage 1 }}
-                    <li class="margin-top-sm--0 margin-top-md--0">
-                        <a href={{ $prevURL }} class="page-link btn btn--plain" rel="prev">Prev</a>
-                    </li>
-                {{ end }}
-                {{ range $pagination.PagesToDisplay }}
-                    {{ if eq .PageNumber $pagination.CurrentPage }}
+        {{ if ne .Data.Response.Count 0 }}
+            <nav aria-label="Pagination breadcrumbs">
+                <ul class="list--neutral list--inline margin-right-sm--1 margin-right-md--1 margin-bottom-sm--7 margin-bottom-md--7">
+                    {{ $prevURL := "" }}
+                    {{ $nextURL := "" }}
+                    {{ range $pagination.PagesToDisplay }}
+                        {{ if eq .PageNumber (subtract $pagination.CurrentPage 1 ) }}{{ $prevURL = .URL }}{{end}}
+                        {{ if eq .PageNumber (add $pagination.CurrentPage 1 ) }}{{ $nextURL = .URL }}{{end}}
+                    {{ end }}
+                    {{ if gt $pagination.CurrentPage 1 }}
                         <li class="margin-top-sm--0 margin-top-md--0">
-                            <a href={{ .URL}} class="page-link btn btn--plain btn--plain-active btn--block" aria-current="true" aria-label="Current page (Page {{ .PageNumber}} of {{ $pagination.TotalPages}})">{{ .PageNumber}}</a>
-                        </li>
-                    {{ else }}
-                        <li class="margin-top-sm--0 margin-top-md--0">
-                            <a href={{ .URL}} class="page-link btn btn--plain" aria-label="Page {{ .PageNumber}} of {{ $pagination.TotalPages}}">{{ .PageNumber}}</a>
+                            <a href={{ $prevURL }} class="page-link btn btn--plain" rel="prev">Prev</a>
                         </li>
                     {{ end }}
-                {{ end }}
-                {{ if lt $pagination.CurrentPage $pagination.TotalPages }}
-                    <li class="margin-top-sm--0 margin-top-md--0">
-                        <a href={{ $nextURL }} class="page-link btn btn--plain" rel="next">Next</a>
-                    </li>
-                {{ end }}
-            </ul>
-        </nav>
+                    {{ range $pagination.PagesToDisplay }}
+                        {{ if eq .PageNumber $pagination.CurrentPage }}
+                            <li class="margin-top-sm--0 margin-top-md--0">
+                                <a href={{ .URL}} class="page-link btn btn--plain btn--plain-active btn--block" aria-current="true" aria-label="Current page (Page {{ .PageNumber}} of {{ $pagination.TotalPages}})">{{ .PageNumber}}</a>
+                            </li>
+                        {{ else }}
+                            <li class="margin-top-sm--0 margin-top-md--0">
+                                <a href={{ .URL}} class="page-link btn btn--plain" aria-label="Page {{ .PageNumber}} of {{ $pagination.TotalPages}}">{{ .PageNumber}}</a>
+                            </li>
+                        {{ end }}
+                    {{ end }}
+                    {{ if lt $pagination.CurrentPage $pagination.TotalPages }}
+                        <li class="margin-top-sm--0 margin-top-md--0">
+                            <a href={{ $nextURL }} class="page-link btn btn--plain" rel="next">Next</a>
+                        </li>
+                    {{ end }}
+                </ul>
+            </nav>
+        {{end}}
     </div>
     <div class="col col--md-12 col--lg-12 margin-top-md--2 padding-left--1">
-        <div class="baseline">
-            <label for="limit-size">Results per page:</label>
-            <select name="limit" id="limit-size" class="input select font-size--14 width-auto js-auto-submit__input">
-                {{ range $pagination.LimitOptions }}
-                    <option value={{.}} {{ if eq . $pagination.Limit }}selected{{end}}>{{.}}</option>
-                {{ end }}
-            </select>
-            <button class="btn btn--primary btn--thin btn--small hide--md" type="submit">Submit</button>
-        </div>
+        {{ if ne .Data.Response.Count 0 }}
+            <div class="baseline">
+                <label for="limit-size">Results per page:</label>
+                <select name="limit" id="limit-size" class="input select font-size--14 width-auto js-auto-submit__input">
+                    {{ range $pagination.LimitOptions }}
+                        <option value={{.}} {{ if eq . $pagination.Limit }}selected{{end}}>{{.}}</option>
+                    {{ end }}
+                </select>
+                <button class="btn btn--primary btn--thin btn--small hide--md" type="submit">Submit</button>
+            </div>
+        {{end}}
     </div>
 </form>

--- a/assets/templates/search/pagination.tmpl
+++ b/assets/templates/search/pagination.tmpl
@@ -1,0 +1,48 @@
+{{ $pagination := .Data.Pagination }}
+<form id="js-pagination-container" class="js-auto-submit__form">
+    <div class="col col--md-22 col--lg-28">
+        <nav aria-label="Pagination breadcrumbs">
+            <ul class="list--neutral list--inline margin-right-sm--1 margin-right-md--1 margin-bottom-sm--7 margin-bottom-md--7">
+                {{ $prevURL := "" }}
+                {{ $nextURL := "" }}
+                {{ range $pagination.PagesToDisplay }}
+                    {{ if eq .PageNumber (subtract $pagination.CurrentPage 1 ) }}{{ $prevURL = .URL }}{{end}}
+                    {{ if eq .PageNumber (add $pagination.CurrentPage 1 ) }}{{ $nextURL = .URL }}{{end}}
+                {{ end }}
+                {{ if gt $pagination.CurrentPage 1 }}
+                    <li class="margin-top-sm--0 margin-top-md--0">
+                        <a href={{ $prevURL }} class="page-link btn btn--plain" rel="prev">Prev</a>
+                    </li>
+                {{ end }}
+                {{ range $pagination.PagesToDisplay }}
+                    {{ if eq .PageNumber $pagination.CurrentPage }}
+                        <li class="margin-top-sm--0 margin-top-md--0">
+                            <a href={{ .URL}} class="page-link btn btn--plain btn--plain-active btn--block" aria-current="true" aria-label="Current page (Page {{ .PageNumber}} of {{ $pagination.TotalPages}})">{{ .PageNumber}}</a>
+                        </li>
+                    {{ else }}
+                        <li class="margin-top-sm--0 margin-top-md--0">
+                            <a href={{ .URL}} class="page-link btn btn--plain" aria-label="Page {{ .PageNumber}} of {{ $pagination.TotalPages}}">{{ .PageNumber}}</a>
+                        </li>
+                    {{ end }}
+                {{ end }}
+                {{ if lt $pagination.CurrentPage $pagination.TotalPages }}
+                    <li class="margin-top-sm--0 margin-top-md--0">
+                        <a href={{ $nextURL }} class="page-link btn btn--plain" rel="next">Next</a>
+                    </li>
+                {{ end }}
+            </ul>
+        </nav>
+    </div>
+    <div class="col col--md-12 col--lg-12 margin-top-md--2 padding-left--1">
+        <div class="baseline">
+            <label for="limit-size">Results per page:</label>
+            <select name="limit" id="limit-size" class="input select font-size--14 width-auto js-auto-submit__input">
+                {{ range $pagination.LimitOptions }}
+                    <option value={{.}} {{ if eq . $pagination.Limit }}selected{{end}}>{{.}}</option>
+                {{ end }}
+            </select>
+            <button class="btn btn--primary btn--thin btn--small hide--md" type="submit">Submit</button>
+        </div>
+    </div>
+    <input type="hidden" name="page" value={{ $pagination.CurrentPage}} class="js-auto-submit__input">
+</form>

--- a/assets/templates/search/results.tmpl
+++ b/assets/templates/search/results.tmpl
@@ -1,31 +1,44 @@
 {{ $lang := .Language }}
 <div id="results" class="results">    
-    <div class="search-results ">
-        <ul class="list--neutral flush">
-            {{ range .Data.Response.Items }}
-                <li class="col col--md-34 col--lg-40 search-results__item">
-                    <h3 class="search-results__title underline-link">
-                        <a href="{{ .URI}}">{{ .Description.Title}}</a>
-                    </h3>
-                    <p class="search-results__meta font-size--16">
-                        {{ .Type}}
-                        |
-                        {{ localise "ReleasedOn" $lang 1 }} {{dateFormat .Description.ReleaseDate}}
-                    </p>
-                    <div class="search-results__summary font-size--16">
-                        {{ .Description.Summary}}
-                    </div>
-                    {{ if .Description.Keywords }}
-                        {{ $numberOfKeywords := len .Description.Keywords }}
-                        <p class="search-results__keywords font-size--16">
-                            {{ localise "Keywords" $lang 4 }}: 
-                            {{ range $i, $el := .Description.Keywords }}
-                                {{$el}}{{ if notLastItem $numberOfKeywords $i }},{{end}}
-                            {{end}}
+    {{ if ne .Data.Response.Count 0 }}
+        <div class="search-results ">
+            <ul class="list--neutral flush">
+                {{ range .Data.Response.Items }}
+                    <li class="col col--md-34 col--lg-40 search-results__item">
+                        <h3 class="search-results__title underline-link">
+                            <a href="{{ .URI}}">{{ .Description.Title}}</a>
+                        </h3>
+                        <p class="search-results__meta font-size--16">
+                            {{ .Type}}
+                            |
+                            {{ localise "ReleasedOn" $lang 1 }} {{dateFormat .Description.ReleaseDate}}
                         </p>
-                    {{end}}
-                </li>
-            {{end}}
-        </ul>
-    </div>
+                        <div class="search-results__summary font-size--16">
+                            {{ .Description.Summary}}
+                        </div>
+                        {{ if .Description.Keywords }}
+                            {{ $numberOfKeywords := len .Description.Keywords }}
+                            <p class="search-results__keywords font-size--16">
+                                {{ localise "Keywords" $lang 4 }}: 
+                                {{ range $i, $el := .Description.Keywords }}
+                                    {{$el}}{{ if notLastItem $numberOfKeywords $i }},{{end}}
+                                {{end}}
+                            </p>
+                        {{end}}
+                    </li>
+                {{end}}
+            </ul>
+        </div>
+    {{else}}
+        <div id="js-search-help" class="col col--lg-42">
+            <h2 class="margin-top-sm--0 margin-top-md--2 margin-top-lg--2">You could try one of the following:</h2>
+            <ul>
+                <li>search again using different words</li>
+            </ul>
+        </div>
+        <div class="search-results margin-top-md--2">
+            <ul class="list--neutral flush">
+            </ul>
+        </div>
+    {{end}}
 </div>

--- a/render/helpers.go
+++ b/render/helpers.go
@@ -160,6 +160,10 @@ func Loop(n, m int) []int {
 	return arr
 }
 
+func Add(x, y int) int {
+	return x + y
+}
+
 func Subtract(x, y int) int {
 	return x - y
 }

--- a/render/helpers_test.go
+++ b/render/helpers_test.go
@@ -12,6 +12,12 @@ func TestLegacyDatasetDownloadURI(t *testing.T) {
 	})
 }
 
+func TestAdd(t *testing.T) {
+	Convey("add should return expected value", t, func() {
+		So(Add(99, 1), ShouldEqual, 100)
+	})
+}
+
 func TestSubtract(t *testing.T) {
 	Convey("substract should return expected value", t, func() {
 		So(Subtract(100, 1), ShouldEqual, 99)

--- a/service/service.go
+++ b/service/service.go
@@ -37,6 +37,7 @@ func Run(ctx context.Context, cfg *config.Config, taxonomyRedirects map[string]s
 			"DatePeriodFormat":            renderHelpers.DatePeriodFormat,
 			"last":                        renderHelpers.Last,
 			"loop":                        renderHelpers.Loop,
+			"add":                         renderHelpers.Add,
 			"subtract":                    renderHelpers.Subtract,
 			"slug":                        renderHelpers.Slug,
 			"markdown":                    renderHelpers.Markdown,


### PR DESCRIPTION
## PLEASE NOTE: This PR is built on top of PR https://github.com/ONSdigital/dp-frontend-renderer/pull/564

### What
**Describe what you have changed and why.**
- Add search pagination to the search page
- Add a helper function `Add`

### How to review
**Describe the steps required to test the changes.**
- Check if the code makes sense
- Can test locally by running web instances, `dp-search-api`, `dp-frontend-search-controller` and then on the browser, go to `http://localhost:20000/search`
- Go to the bottom of the web and move to the next page. You will notice that the search results will change to show the next offset of search results
- Change the limit of results to be displayed and the number of results available on the screen will be updated accordingly

Please note that updates to `dp-frontend-search-controller` is still in PR (https://github.com/ONSdigital/dp-frontend-search-controller/pull/16), therefore you need to pull my commits locally from that PR, run the controller, and test from there. This PR description box will be updated once it has been merged into any environment.

**ALSO, you need to change the feature flag `NewSearchEnabled` in the dp-frontend-router to `true`**

### Who can review
**Describe who worked on the changes, so that other people can review.**
Anyone