### PR TITLE
edited link to time series tool to use relative path

### DIFF
--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -11,7 +11,7 @@
         </h1>
         <span class="hide--sm font-size--18 line-height--56"> – </span>
         <span class="margin-left--0 line-height--56">
-            <a href="https://www.ons.gov.uk/timeseriestool" class="tile__link">From our time series explorer</a>
+            <a href="/timeseriestool" class="tile__link">From our time series explorer</a>
         </span>
     </header>
     {{ if .Data.HasMainFigures }}


### PR DESCRIPTION
### What

Fixed time series explorer link in the home page so that it's relative to the domain rather than hardcoded to the prod site

### How to review

Load the ons home page locally from the develop branch then then click on the link "From our time series explorer" next to the "Main figures" title to navigate to the time series explorer page. See the address of the time series explorer page is incorrectly being directed to the prod website (ons.gov.uk). Check out this branch then after following the time series explorer link on the homepage, the time series explorer page address should be localhost:8081.

### Who can review

Anyone
