### PR TITLE
Feature/homepage census tile

### DIFF
--- a/assets/locales/active.cy.toml
+++ b/assets/locales/active.cy.toml
@@ -226,6 +226,10 @@ one = "Poblogaeth ac ymfudo"
 description = "Well-being"
 one = "Lles"
 
+[Census2021]
+description = "Cyfrifiad 2021"
+one = "Cyfrifiad 2021"
+
 [Census2021TakingPart]
 description = "Mae cymryd rhan yn hanfodol er mwyn sicrhau eich bod chi a'ch cymuned yn cael y gwasanaethau sydd eu hangen arnoch chi."
 one = "Mae cymryd rhan yn hanfodol er mwyn sicrhau eich bod chi a'ch cymuned yn cael y gwasanaethau sydd eu hangen arnoch chi."

--- a/assets/locales/active.cy.toml
+++ b/assets/locales/active.cy.toml
@@ -226,6 +226,22 @@ one = "Poblogaeth ac ymfudo"
 description = "Well-being"
 one = "Lles"
 
+[Census2021TakingPart]
+description = "Mae cymryd rhan yn hanfodol er mwyn sicrhau eich bod chi a'ch cymuned yn cael y gwasanaethau sydd eu hangen arnoch chi."
+one = "Mae cymryd rhan yn hanfodol er mwyn sicrhau eich bod chi a'ch cymuned yn cael y gwasanaethau sydd eu hangen arnoch chi."
+
+[Census2021CompleteLink]
+description = "Cwblhewch Gyfrifiad 2021."
+one = "Cwblhewch Gyfrifiad 2021."
+
+[Census2021Preparation]
+description = "Ein paratoadau ar gyfer Cyfrifiad 2021 a thu hwnt."
+one = "Ein paratoadau ar gyfer Cyfrifiad 2021 a thu hwnt."
+
+[Census2021ResearchLink]
+description = "Gwaith ymchwil a chynllunio ar gyfer y cyfrifiad."
+one = "Gwaith ymchwil a chynllunio ar gyfer y cyfrifiad."
+
 [SurveyTakingPart]
 description = "Taking part in a survey?"
 one = "Cymryd rhan mewn arolwg?"

--- a/assets/locales/active.en.toml
+++ b/assets/locales/active.en.toml
@@ -218,6 +218,22 @@ one = "Population and migration"
 description = "Well-being"
 one = "Well-being"
 
+[Census2021TakingPart]
+description = "Taking part is vital to make sure you and your community get the services you need."
+one = "Taking part is vital to make sure you and your community get the services you need."
+
+[Census2021CompleteLink]
+description = "Complete Census 2021."
+one = "Complete Census 2021."
+
+[Census2021Preparation]
+description = "Our preparation for Census 2021 and beyond."
+one = "Our preparation for Census 2021 and beyond."
+
+[Census2021ResearchLink]
+description = "Census research and planning."
+one = "Census research and planning."
+
 [SurveyTakingPart]
 description = "Taking part in a survey?"
 one = "Taking part in a survey?"

--- a/assets/locales/active.en.toml
+++ b/assets/locales/active.en.toml
@@ -218,6 +218,10 @@ one = "Population and migration"
 description = "Well-being"
 one = "Well-being"
 
+[Census2021]
+description = "Census 2021"
+one = "Census 2021"
+
 [Census2021TakingPart]
 description = "Taking part is vital to make sure you and your community get the services you need."
 one = "Taking part is vital to make sure you and your community get the services you need."

--- a/assets/templates/homepage.tmpl
+++ b/assets/templates/homepage.tmpl
@@ -4,7 +4,7 @@
         {{ template "homepage/main-figures" . }}
 
         <div>
-            {{ template "homepage/latest-releases" . }}
+            {{ template "homepage/census-tile" . }}
         </div>
     </div>
     {{ template "homepage/promos" . }}

--- a/assets/templates/homepage.tmpl
+++ b/assets/templates/homepage.tmpl
@@ -2,10 +2,9 @@
     {{ template "partials/banners/covid" . }}
     <div class="wrapper">
         {{ template "homepage/main-figures" . }}
-
-        <div>
-            {{ template "homepage/census-tile" . }}
         </div>
+<div class="wrapper">
+        {{ template "homepage/census-tile" . }}
     </div>
     {{ template "homepage/promos" . }}
     <div class="wrapper background-gallery">

--- a/assets/templates/homepage.tmpl
+++ b/assets/templates/homepage.tmpl
@@ -2,9 +2,10 @@
     {{ template "partials/banners/covid" . }}
     <div class="wrapper">
         {{ template "homepage/main-figures" . }}
+
+        <div>
+            {{ template "homepage/census-tile" . }}
         </div>
-<div class="wrapper">
-        {{ template "homepage/census-tile" . }}
     </div>
     {{ template "homepage/promos" . }}
     <div class="wrapper background-gallery">

--- a/assets/templates/homepage/census-tile.tmpl
+++ b/assets/templates/homepage/census-tile.tmpl
@@ -1,0 +1,16 @@
+<article class="tile tile__content promo__background--plum-gradient col col--lg-29 margin-top-lg--2 margin-top-md--2 margin-left-lg--1 height-lg--31">
+    <header class="margin-top--1">
+        <h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0">
+            <span class="tile__title">{{ localise "LatestReleases" .Language 1 }}</span>
+        </h2>
+    </header>
+    <div class="margin-top--1">
+        <span>Taking part is vital to make sure you and your community get the services you need.</span><br>
+        <a href="">Complete Census 2021.</a>
+    </div>
+    <div class="margin-top--1">
+        <p class="margin-top--0 padding-top--0">Our preparation for Census 2021 and beyond<br>
+        <a href="">Census research and planning.</a>
+        </p>
+    </div>
+</article>

--- a/assets/templates/homepage/census-tile.tmpl
+++ b/assets/templates/homepage/census-tile.tmpl
@@ -1,4 +1,4 @@
-<article class="tile tile__content promo__background--plum-gradient col col--lg-29 margin-top-lg--2 margin-top-md--2 {{if eq .Language "en" }} height-lg--31 {{ else }} height-lg--41 {{end}}hide--sm">
+<article class="tile tile__content promo__background--plum-gradient col col--lg-29 margin-top-lg--2 margin-top-md--2 margin-left-lg--1 {{if eq .Language "en" }}height-lg--31 {{ else }}height-lg--41 {{end}}hide--sm">
     <header class="margin-top--1">
         <h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0">
                 {{if eq .Language "en" }}

--- a/assets/templates/homepage/census-tile.tmpl
+++ b/assets/templates/homepage/census-tile.tmpl
@@ -9,11 +9,11 @@
         </h2>
     </header>
     <div class="margin-top--1">
-        Taking part is vital to make sure you and your community get the services you need.<br>
-        <a class="text--white font-weight-700 underline-link" href="">Complete Census 2021.</a>
+        {{ localise "Census2021TakingPart" .Language 1 }}<br>
+        <a class="text--white font-weight-700 underline-link" href="">{{ localise "Census2021CompleteLink" .Language 1 }}</a>
     </div>
     <div class="margin-top--1">
-        Our preparation for Census 2021 and beyond.<br>
-        <a class="text--white font-weight-700 underline-link" href="">Census research and planning.</a>
+        {{ localise "Census2021Preparation" .Language 1 }}<br>
+        <a class="text--white font-weight-700 underline-link" href="">{{ localise "Census2021ResearchLink" .Language 1 }}</a>
     </div>
 </article>

--- a/assets/templates/homepage/census-tile.tmpl
+++ b/assets/templates/homepage/census-tile.tmpl
@@ -14,10 +14,10 @@
     </header>
     <div class="margin-top--0">
         {{ localise "Census2021TakingPart" .Language 1 }}<br>
-        <a class="text--white font-weight-700 underline-link" href="">{{ localise "Census2021CompleteLink" .Language 1 }}</a>
+        <a class="text--white font-weight-700 underline-link" {{if eq .Language "en" }}href="https://www.census.gov.uk" {{ else }}href="https://www.cyfrifiad.gov.uk"{{end}}>{{ localise "Census2021CompleteLink" .Language 1 }}</a>
     </div>
     <div class="margin-top--1">
         {{ localise "Census2021Preparation" .Language 1 }}<br>
-        <a class="text--white font-weight-700 underline-link" href="">{{ localise "Census2021ResearchLink" .Language 1 }}</a>
+        <a class="text--white font-weight-700 underline-link" {{if eq .Language "en" }}href="https://www.ons.gov.uk/census" {{ else }}href="https://cy.ons.gov.uk/census"{{end}}>{{ localise "Census2021ResearchLink" .Language 1 }}</a>
     </div>
 </article>

--- a/assets/templates/homepage/census-tile.tmpl
+++ b/assets/templates/homepage/census-tile.tmpl
@@ -1,10 +1,16 @@
-<article class="tile tile__content promo__background--plum-gradient col col--lg-29 margin-top-lg--2 margin-top-md--2 margin-left-lg--1 height-lg--32 hide--sm">
+<article class="tile tile__content promo__background--plum-gradient col col--lg-29 margin-top-lg--2 margin-top-md--2 margin-left-lg--1 {{if eq .Language "en" }} height-lg--31 {{ else }} height-lg--41 {{end}}hide--sm">
     <header class="margin-top--1">
         <h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0">
             <span class="tile__title">
-                <img src="https://cdn.ons.gov.uk/assets/images/logo-census-2021-white-landscape.svg" alt="" class="header__svg-logo"
-                xmlns="http://www.w3.org/2000/svg" focusable="false" width="209" height="40" viewBox="0 0 228 44" aria-labelledby="census-logo-en-alt">
-                <title id="census-logo-en-alt">Census 2021</title>
+                {{if eq .Language "en" }}
+                    <img src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape.svg" alt="" class="header__svg-logo"
+                    xmlns="http://www.w3.org/2000/svg" focusable="false" width="209" height="40" viewBox="0 0 228 44" aria-labelledby="census-logo-en-alt">
+                {{ else }}
+                    <img src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape-cy.svg" alt="" class="header__svg-logo"
+                    xmlns="http://www.w3.org/2000/svg" focusable="false" width="209" height="40" viewBox="0 0 228 44" aria-labelledby="census-logo-en-alt">
+                {{ end }}
+                <title id="census-logo-en-alt">{{ localise "Census2021" .Language 1 }}</title>
+                </img>
             </span>
         </h2>
     </header>

--- a/assets/templates/homepage/census-tile.tmpl
+++ b/assets/templates/homepage/census-tile.tmpl
@@ -1,7 +1,11 @@
-<article class="tile tile__content promo__background--plum-gradient col col--lg-29 margin-top-lg--2 margin-top-md--2 margin-left-lg--1 height-lg--31">
+<article class="tile tile__content promo__background--plum-gradient col col--lg-29 margin-top-lg--2 margin-top-md--2 margin-left-lg--1 height-lg--32 hide--sm">
     <header class="margin-top--1">
         <h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0">
-            <span class="tile__title">Census</span>
+            <span class="tile__title">
+                <img src="https://cdn.ons.gov.uk/assets/images/logo-census-2021-white-landscape.svg" alt="" class="header__svg-logo"
+                xmlns="http://www.w3.org/2000/svg" focusable="false" width="209" height="40" viewBox="0 0 228 44" aria-labelledby="census-logo-en-alt">
+                <title id="census-logo-en-alt">Census 2021</title>
+            </span>
         </h2>
     </header>
     <div class="margin-top--1">

--- a/assets/templates/homepage/census-tile.tmpl
+++ b/assets/templates/homepage/census-tile.tmpl
@@ -1,17 +1,15 @@
-<article class="promo__background--plum-gradient tile tile__content col col--lg-29 margin-top-lg--2 margin-top-md--2 margin-left-lg--1 height-lg--31">
+<article class="tile tile__content promo__background--plum-gradient col col--lg-29 margin-top-lg--2 margin-top-md--2 margin-left-lg--1 height-lg--31">
     <header class="margin-top--1">
         <h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0">
-            <span class="tile__title">{{ localise "LatestReleases" .Language 1 }}</span>
+            <span class="tile__title">Census</span>
         </h2>
     </header>
     <div class="margin-top--1">
-        <p>Taking part is vital to make sure you and your community get the services you need.</span><br>
-        <a href="">Complete Census 2021.</a>
+        Taking part is vital to make sure you and your community get the services you need.<br>
+        <a class="text--white font-weight-700 underline-link" href="">Complete Census 2021.</a>
     </div>
     <div class="margin-top--1">
-        <p class="promo__description margin-top--0 padding-top--0">Our preparation for Census 2021 and beyond
-        <br>
-        <a class="underline-link" href="">Census research and planning.</a>
-        </p>
+        Our preparation for Census 2021 and beyond.<br>
+        <a class="text--white font-weight-700 underline-link" href="">Census research and planning.</a>
     </div>
 </article>

--- a/assets/templates/homepage/census-tile.tmpl
+++ b/assets/templates/homepage/census-tile.tmpl
@@ -1,16 +1,17 @@
-<article class="tile tile__content promo__background--plum-gradient col col--lg-29 margin-top-lg--2 margin-top-md--2 margin-left-lg--1 height-lg--31">
+<article class="promo__background--plum-gradient tile tile__content col col--lg-29 margin-top-lg--2 margin-top-md--2 margin-left-lg--1 height-lg--31">
     <header class="margin-top--1">
         <h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0">
             <span class="tile__title">{{ localise "LatestReleases" .Language 1 }}</span>
         </h2>
     </header>
     <div class="margin-top--1">
-        <span>Taking part is vital to make sure you and your community get the services you need.</span><br>
+        <p>Taking part is vital to make sure you and your community get the services you need.</span><br>
         <a href="">Complete Census 2021.</a>
     </div>
     <div class="margin-top--1">
-        <p class="margin-top--0 padding-top--0">Our preparation for Census 2021 and beyond<br>
-        <a href="">Census research and planning.</a>
+        <p class="promo__description margin-top--0 padding-top--0">Our preparation for Census 2021 and beyond
+        <br>
+        <a class="underline-link" href="">Census research and planning.</a>
         </p>
     </div>
 </article>

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -133,7 +133,7 @@
             </article>
         </div>
         <div class="col col--lg-29 col--md-29">
-            <article class="tile tile__content margin-top-lg--2 margin-top-md--2 margin-left-md--1 margin-left-lg--0 height-lg--32">
+            <article class="tile tile__content margin-top-lg--2 margin-top-md--2 margin-left-md--1 margin-left-lg--0 {{if eq .Language "en" }} height-lg--31 {{ else }} height-lg--41 {{end}}height-lg--31">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">UK population</span></h2></header>
                 {{ if $Population.Figure }}
                     <div class="margin-top--1">Mid-year estimate ({{ DatePeriodFormat $Population.Date }})</div>

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -151,6 +151,9 @@
             {{ end }}
             </article>
         </div>
+        <div class="col col--lg-29 col--md-29">
+            {{ template "homepage/census-tile" . }}
+        </div>
     </div>
     <!--medium-->
     <div class="flex stretch col-wrap hide--sm hide--lg">

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -151,9 +151,6 @@
             {{ end }}
             </article>
         </div>
-        <div class="col col--lg-29 col--md-29">
-            {{ template "homepage/census-tile" . }}
-        </div>
     </div>
     <!--medium-->
     <div class="flex stretch col-wrap hide--sm hide--lg">

--- a/assets/templates/homepage/main-figures.tmpl
+++ b/assets/templates/homepage/main-figures.tmpl
@@ -133,7 +133,7 @@
             </article>
         </div>
         <div class="col col--lg-29 col--md-29">
-            <article class="tile tile__content margin-top-lg--2 margin-top-md--2 margin-left-md--1 margin-left-lg--0 height-lg--31">
+            <article class="tile tile__content margin-top-lg--2 margin-top-md--2 margin-left-md--1 margin-left-lg--0 height-lg--32">
                 <header class="margin-top--1"><h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0"><span class="tile__title">UK population</span></h2></header>
                 {{ if $Population.Figure }}
                     <div class="margin-top--1">Mid-year estimate ({{ DatePeriodFormat $Population.Date }})</div>

--- a/assets/templates/homepage/promos.tmpl
+++ b/assets/templates/homepage/promos.tmpl
@@ -1,10 +1,19 @@
-<div class="flex wrapper flex-wrap-wrap stretch tiles background-gallery margin-top--2 margin-bottom--2 flex-basis-sm--full">
+<div class="flex wrapper flex-wrap-wrap stretch tiles background-gallery margin-top--2 margin-bottom--2 flex-basis-sm--full hide--sm">
         {{ template "partials/banners/census-tile-sm" . }}
     <div class="col--md-23 col--lg-29 margin-right-md--1 margin-bottom-sm--2 flex-basis-sm--full">
         {{ template "partials/banners/latest-releases-small" . }}
     </div>
     <div class="col--md-23 col--lg-29 margin-bottom-sm--2 flex-basis-sm--full">
         {{ template "partials/banners/survey" . }}
+    </div>
+</div>
+<div class="flex wrapper flex-wrap-wrap stretch tiles background-gallery margin-top--2 margin-bottom--2 flex-basis-sm--full hide--lg hide--md">
+        {{ template "partials/banners/census-tile-sm" . }}
+    <div class="col--md-23 col--lg-29 margin-right-md--1 margin-bottom-sm--2 flex-basis-sm--full">
+        {{ template "partials/banners/survey" . }}
+    </div>
+    <div class="col--md-23 col--lg-29 margin-bottom-sm--2 flex-basis-sm--full">
+        {{ template "partials/banners/latest-releases-small" . }}
     </div>
 </div>
 

--- a/assets/templates/homepage/promos.tmpl
+++ b/assets/templates/homepage/promos.tmpl
@@ -1,10 +1,10 @@
 <div class="flex wrapper flex-wrap-wrap stretch tiles background-gallery margin-top--2 margin-bottom--2 flex-basis-sm--full">
         {{ template "partials/banners/census-tile-sm" . }}
     <div class="col--md-23 col--lg-29 margin-right-md--1 margin-bottom-sm--2 flex-basis-sm--full">
-            {{ template "partials/banners/survey" . }}
+        {{ template "partials/banners/latest-releases-small" . }}
     </div>
     <div class="col--md-23 col--lg-29 margin-bottom-sm--2 flex-basis-sm--full">
-        {{ template "partials/banners/latest-releases-small" . }}
+        {{ template "partials/banners/survey" . }}
     </div>
 </div>
 

--- a/assets/templates/homepage/promos.tmpl
+++ b/assets/templates/homepage/promos.tmpl
@@ -1,8 +1,10 @@
-<div class="flex wrapper flex-wrap-wrap stretch tiles background-gallery margin-top--2 margin-bottom--2">
+<div class="flex wrapper flex-wrap-wrap stretch tiles background-gallery margin-top--2 margin-bottom--2 flex-basis-sm--full">
+        {{ template "partials/banners/census-tile-sm" . }}
     <div class="col--md-23 col--lg-29 margin-right-md--1 margin-bottom-sm--2 flex-basis-sm--full">
+            {{ template "partials/banners/survey" . }}
+    </div>
+    <div class="col--md-23 col--lg-29 margin-bottom-sm--2 flex-basis-sm--full">
         {{ template "partials/banners/latest-releases-small" . }}
     </div>
-    <div class="col--md-23 col--lg-29 flex-basis-sm--full">
-        {{ template "partials/banners/survey" . }}
-    </div>
 </div>
+

--- a/assets/templates/homepage/promos.tmpl
+++ b/assets/templates/homepage/promos.tmpl
@@ -1,8 +1,8 @@
 <div class="flex wrapper flex-wrap-wrap stretch tiles background-gallery margin-top--2 margin-bottom--2">
     <div class="col--md-23 col--lg-29 margin-right-md--1 margin-bottom-sm--2 flex-basis-sm--full">
-        {{ template "partials/banners/survey" . }}
+        {{ template "partials/banners/latest-releases-small" . }}
     </div>
     <div class="col--md-23 col--lg-29 flex-basis-sm--full">
-        {{ template "partials/banners/census" . }}
+        {{ template "partials/banners/survey" . }}
     </div>
 </div>

--- a/assets/templates/partials/banners/census-tile-sm.tmpl
+++ b/assets/templates/partials/banners/census-tile-sm.tmpl
@@ -1,4 +1,4 @@
-<article class="tile tile__content promo__background--plum-gradient col col--lg-29 margin-top-lg--2 margin-top-md--2 {{if eq .Language "en" }} height-lg--31 {{ else }} height-lg--41 {{end}}hide--sm">
+<article class="promo__container tile tile__content promo__background--plum-gradient margin-top-lg--0 margin-top-md--2 height-lg--31 hide--lg hide--md margin-bottom--2 {{if eq .Language "en" }} height-lg--31 {{ else }} height-lg--41 {{end}}">
     <header class="margin-top--1">
         <h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0">
                 {{if eq .Language "en" }}
@@ -6,9 +6,9 @@
                     xmlns="http://www.w3.org/2000/svg" focusable="false" width="209" height="40" viewBox="0 0 228 44" aria-labelledby="census-logo-en-alt">
                 {{ else }}
                     <img src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape-cy.svg" alt="" class="header__svg-logo"
-                    xmlns="http://www.w3.org/2000/svg" focusable="false" width="209" height="40" viewBox="0 0 228 44" aria-labelledby="census-logo-en-alt">
+                    xmlns="http://www.w3.org/2000/svg" focusable="false" width="209" height="40" viewBox="0 0 228 44" aria-labelledby="census-logo-cy-alt">
                 {{ end }}
-                <title id="census-logo-en-alt">{{ localise "Census2021" .Language 1 }}</title>
+                <title id="census-logo-cy-alt">{{ localise "Census2021" .Language 1 }}</title>
                 </img>
         </h2>
     </header>

--- a/assets/templates/partials/banners/census-tile-sm.tmpl
+++ b/assets/templates/partials/banners/census-tile-sm.tmpl
@@ -1,4 +1,4 @@
-<article class="promo__container tile tile__content promo__background--plum-gradient margin-top-lg--0 margin-top-md--2 height-lg--31 hide--lg hide--md margin-bottom--2 {{if eq .Language "en" }} height-lg--31 {{ else }} height-lg--41 {{end}}">
+<article class="promo__container tile tile__content promo__background--plum-gradient margin-top-lg--0 margin-top-md--2 height-lg--31 hide--lg hide--md margin-bottom--2 {{if eq .Language "en" }}height-lg--31 {{ else }}height-lg--41 {{end}}">
     <header class="margin-top--1">
         <h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0">
                 {{if eq .Language "en" }}
@@ -14,10 +14,10 @@
     </header>
     <div class="margin-top--0">
         {{ localise "Census2021TakingPart" .Language 1 }}<br>
-        <a class="text--white font-weight-700 underline-link" href="">{{ localise "Census2021CompleteLink" .Language 1 }}</a>
+        <a class="text--white font-weight-700 underline-link" {{if eq .Language "en" }}href="https://www.census.gov.uk" {{ else }}href="https://www.cyfrifiad.gov.uk"{{end}}>{{ localise "Census2021CompleteLink" .Language 1 }}</a>
     </div>
     <div class="margin-top--1">
         {{ localise "Census2021Preparation" .Language 1 }}<br>
-        <a class="text--white font-weight-700 underline-link" href="">{{ localise "Census2021ResearchLink" .Language 1 }}</a>
+        <a class="text--white font-weight-700 underline-link" {{if eq .Language "en" }}href="https://www.ons.gov.uk/census" {{ else }}href="https://cy.ons.gov.uk/census"{{end}}>{{ localise "Census2021ResearchLink" .Language 1 }}</a>
     </div>
 </article>

--- a/assets/templates/partials/banners/latest-releases-small.tmpl
+++ b/assets/templates/partials/banners/latest-releases-small.tmpl
@@ -1,12 +1,13 @@
-<div class="col--md-23 col--lg-29 flex-basis-sm--full">
-    <article class="tile tile__content margin--0">
+<article class="promo-container">
+    <div class="tile tile__content margin--0">
 	    <header class="margin-top--1">
-	        <h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0">
+	        <h2 class="margin-top--0 padding-top--0 padding-bottom-sm--0 padding-bottom-md--0 padding-bottom-lg--1">
 	            <span class="tile__title">{{ localise "LatestReleases" .Language 1 }}</span>
 	         </h2>
 	    </header>
 	    <div class="padding-bottom--1">
 	        <a href="/releasecalendar">{{ localise "AllReleases" .Language 1 }}</a>
 	    </div>
-	</article>
-</div>
+    </div>
+</article>
+

--- a/assets/templates/partials/banners/latest-releases-small.tmpl
+++ b/assets/templates/partials/banners/latest-releases-small.tmpl
@@ -1,7 +1,7 @@
-<article class="promo-container box__content box__content--homepage">
-    <div class="tile tile__content margin--0">
+<article class="promo-container">
+    <div class="tile tile__content margin--0 padding-left--1 padding-right--1 padding-top--2 padding-bottom--2 tile tile__content margin--0">
 	    <header class="margin-top--1">
-	        <h2 class="margin-top--0 padding-top--0 padding-bottom-sm--0 padding-bottom-md--0 padding-bottom-lg--1">
+	        <h2 class="margin-top--0 padding-top--0 padding-bottom-sm--0 padding-bottom-md--4 padding-bottom-lg--1">
 	            <span class="tile__title">{{ localise "LatestReleases" .Language 1 }}</span>
 	         </h2>
 	    </header>

--- a/assets/templates/partials/banners/latest-releases-small.tmpl
+++ b/assets/templates/partials/banners/latest-releases-small.tmpl
@@ -1,7 +1,8 @@
 <article class="promo-container">
-    <div class="tile tile__content margin--0 padding-left--1 padding-right--1 padding-top--2 padding-bottom--2 tile tile__content margin--0">
+    <div class="tile tile__content margin--0 padding-left--1 padding-right--1 padding-top--2 padding-bottom--2">
 	    <header class="margin-top--1">
-	        <h2 class="margin-top--0 padding-top--0 padding-bottom-sm--0 padding-bottom-md--4 padding-bottom-lg--1">
+	        <h2 class="margin-top--0 padding-top--0 padding-bottom-sm--0 padding-bottom-md--4
+	        {{if eq .Language "en" }} padding-bottom-lg--1 {{ else }} padding-bottom-lg--4 {{end}}">
 	            <span class="tile__title">{{ localise "LatestReleases" .Language 1 }}</span>
 	         </h2>
 	    </header>

--- a/assets/templates/partials/banners/latest-releases-small.tmpl
+++ b/assets/templates/partials/banners/latest-releases-small.tmpl
@@ -1,0 +1,12 @@
+<div class="col--md-23 col--lg-29 flex-basis-sm--full">
+    <article class="tile tile__content margin--0">
+	    <header class="margin-top--1">
+	        <h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0">
+	            <span class="tile__title">{{ localise "LatestReleases" .Language 1 }}</span>
+	         </h2>
+	    </header>
+	    <div class="padding-bottom--1">
+	        <a href="/releasecalendar">{{ localise "AllReleases" .Language 1 }}</a>
+	    </div>
+	</article>
+</div>

--- a/assets/templates/partials/banners/latest-releases-small.tmpl
+++ b/assets/templates/partials/banners/latest-releases-small.tmpl
@@ -1,4 +1,4 @@
-<article class="promo-container">
+<article class="promo-container box__content box__content--homepage">
     <div class="tile tile__content margin--0">
 	    <header class="margin-top--1">
 	        <h2 class="margin-top--0 padding-top--0 padding-bottom-sm--0 padding-bottom-md--0 padding-bottom-lg--1">
@@ -6,7 +6,7 @@
 	         </h2>
 	    </header>
 	    <div class="padding-bottom--1">
-	        <a href="/releasecalendar">{{ localise "AllReleases" .Language 1 }}</a>
+	        <a class="underline-link" href="/releasecalendar">{{ localise "AllReleases" .Language 1 }}</a>
 	    </div>
     </div>
 </article>

--- a/assets/templates/partials/banners/survey.tmpl
+++ b/assets/templates/partials/banners/survey.tmpl
@@ -1,5 +1,5 @@
 <a class="promo__container" href="/surveys">
-    <section class="promo__background--blue-gradient box__content box__content--homepage">
+    <section class="tile promo__background--blue-gradient box__content box__content--homepage">
         <div class="promo__body padding-left--1 padding-right--1 padding-top--2 padding-bottom--2">
             <img class="hide--md-only" src="https://cdn.ons.gov.uk/assets/images/icon-checkbox.svg" alt="">
             <div class="promo__copy">


### PR DESCRIPTION
### What

- make Census tile with links to census page and ons page about census
- move Latest Releases to the promo section
- move Survey promo to the right promo
- stack Census tile and Latest Release to the right in Welsh and English

### How to review

Go to homepage, see census tile is a small promo. Pull this branch, see that Census and Survey are stacked to the right, can navigate to census page and research page. In medium viewports, census tile stretches across screen, in small viewports this has been moved to the promo section. 

### Who can review

Front-end dev only. 
