### PR TITLE
Fixed bug where href associated with national statistics image pointed to a page which no longer exists.

### DIFF
--- a/assets/templates/datasetLandingPage/filterable.tmpl
+++ b/assets/templates/datasetLandingPage/filterable.tmpl
@@ -253,7 +253,7 @@
             <div class="tiles__content tiles__content--nav">
                <p class="margin-bottom--0">
                   Certified by the UK Statistics Authority as compliant with the Code of Practice for Official Statistics.
-                  <a class="block underline-link" href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/">Learn more</a>
+                  <a class="block underline-link" href="https://uksa.statisticsauthority.gov.uk/about-the-authority/what-we-do/uk-statistical-system/types-of-official-statistics/">Learn more</a>
                </p>
             </div>
          </div>

--- a/assets/templates/datasetLandingPage/nomis.tmpl
+++ b/assets/templates/datasetLandingPage/nomis.tmpl
@@ -235,7 +235,7 @@
           <div class="tiles__content tiles__content--nav">
             <p class="margin-bottom--0">
               Certified by the UK Statistics Authority as compliant with the Code of Practice for Official Statistics.
-              <a class="block underline-link" href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/">Learn more</a>
+              <a class="block underline-link" href="https://uksa.statisticsauthority.gov.uk/about-the-authority/what-we-do/uk-statistical-system/types-of-official-statistics/">Learn more</a>
             </p>
           </div>
         </div>

--- a/assets/templates/datasetLandingPage/static.tmpl
+++ b/assets/templates/datasetLandingPage/static.tmpl
@@ -79,7 +79,7 @@
         <ul class="col-wrap meta__list">
             <li class="col col--md-12 col--lg-15 meta__item">
                 {{ if .DatasetLandingPage.IsNationalStatistic}}
-                <a href="https://www.statisticsauthority.gov.uk/national-statistician/types-of-official-statistics/">
+                <a href="https://uksa.statisticsauthority.gov.uk/about-the-authority/what-we-do/uk-statistical-system/types-of-official-statistics/">
                     <img class="meta__image" src="/img/national-statistics.png" alt="This is an accredited National Statistic. Click for information about types of official statistics.">
                 </a>
                 {{ end }}


### PR DESCRIPTION
### What

Fixed bug where href associated with national statistics image pointed to a page which no longer exists.

### How to review

Review link has indeed been updated and points to the correct page.

### Who can review

Anyone.