### PR TITLE
Update log.go requirement to v2 in go.mod and imports.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,18 +4,18 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/ONSdigital/dp-api-clients-go v1.33.6 // indirect
 	github.com/ONSdigital/dp-frontend-models v1.12.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
-	github.com/ONSdigital/dp-net v1.0.11 // indirect
 	github.com/ONSdigital/go-ns v0.0.0-20200902154605-290c8b5ba5eb
 	github.com/ONSdigital/log.go v1.0.1
+	github.com/ONSdigital/log.go/v2 v2.0.1 // indirect
 	github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/pat v1.0.1
 	github.com/gosimple/slug v1.9.0
 	github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519 // indirect
+	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/justinas/alice v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/nicksnyder/go-i18n/v2 v2.1.2
@@ -24,7 +24,6 @@ require (
 	github.com/smartystreets/assertions v1.0.1 // indirect
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/unrolled/render v1.0.3
-	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect
 	golang.org/x/text v0.3.5
 	gopkg.in/russross/blackfriday.v2 v2.1.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0 h1:ExIUlHC6uBdBlFwt/gAI0ApSzpyig
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
 github.com/ONSdigital/dp-api-clients-go v1.33.6 h1:RsVZ7a5Z8tpUpe6ARA2+XmdbG8BAYCJXBWkX6fDBnyE=
 github.com/ONSdigital/dp-api-clients-go v1.33.6/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
+github.com/ONSdigital/dp-api-clients-go v1.34.3 h1:nS3ZG3Eql9T68Q0IFehpnqkUy2AFoTDktVgaD90Yj+s=
+github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-frontend-models v1.11.1 h1:yxgH7xMnFg1A11nzf9Dwwyi9QS421T7a4eOVbMk0/fM=
 github.com/ONSdigital/dp-frontend-models v1.11.1/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
@@ -23,6 +25,8 @@ github.com/ONSdigital/dp-net v1.0.7/go.mod h1:1QFzx32FwPKD2lgZI6MtcsUXritsBdJihl
 github.com/ONSdigital/dp-net v1.0.10/go.mod h1:2lvIKOlD4T3BjWQwjHhBUO2UNWDk82u/+mHRn0R3C9A=
 github.com/ONSdigital/dp-net v1.0.11 h1:BJi+e21NuwEaqANDhEzWeaQgPuoSWkQS49mJALgZJKs=
 github.com/ONSdigital/dp-net v1.0.11/go.mod h1:2lvIKOlD4T3BjWQwjHhBUO2UNWDk82u/+mHRn0R3C9A=
+github.com/ONSdigital/dp-net v1.0.12 h1:Vd06ia1FXKR9uyhzWykQ52b1LTp4N0VOLnrF7KOeP78=
+github.com/ONSdigital/dp-net v1.0.12/go.mod h1:2lvIKOlD4T3BjWQwjHhBUO2UNWDk82u/+mHRn0R3C9A=
 github.com/ONSdigital/dp-rchttp v0.0.0-20190919143000-bb5699e6fd59/go.mod h1:KkW68U3FPuivW4ogi9L8CPKNj9ZxGko4qcUY7KoAAkQ=
 github.com/ONSdigital/dp-rchttp v0.0.0-20200114090501-463a529590e8/go.mod h1:821jZtK0oBsV8hjIkNr8vhAWuv0FxJBPJuAHa2B70Gk=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
@@ -35,6 +39,8 @@ github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQ
 github.com/ONSdigital/log.go v1.0.1-0.20200805145532-1f25087a0744/go.mod h1:y4E9MYC+cV9VfjRD0UBGj8PA7H3wABqQi87/ejrDhYc=
 github.com/ONSdigital/log.go v1.0.1 h1:SZ5wRZAwlt2jQUZ9AUzBB/PL+iG15KapfQpJUdA18/4=
 github.com/ONSdigital/log.go v1.0.1/go.mod h1:dIwSXuvFB5EsZG5x44JhsXZKMd80zlb0DZxmiAtpL4M=
+github.com/ONSdigital/log.go/v2 v2.0.1 h1:dRMvWdCQr0bJyg42c7I9lycHF04s+JBo/6wQnpFQNMs=
+github.com/ONSdigital/log.go/v2 v2.0.1/go.mod h1:PR7vXrv9dZKUc7SI/0toxBbStk84snmybBnWpe+xY2o=
 github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2 h1:t8KYCwSKsOEZBFELI4Pn/phbp38iJ1RRAkDFNin1aak=
 github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385 h1:clC1lXBpe2kTj2VHdaIu9ajZQe4kcEY9j0NsnDDBZ3o=
@@ -66,6 +72,8 @@ github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e h1:0aewS5NT
 github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519 h1:nqAlWFEdqI0ClbTDrhDvE/8LeQ4pftrqKUX9w5k0j3s=
 github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=
@@ -126,6 +134,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0 h1:g9s1Ppvvun/fI+BptTMj909BBIcGrzQ32k9FNlcevOE=
+golang.org/x/sys v0.0.0-20210414055047-fe65e336abe0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=

--- a/render/handler.go
+++ b/render/handler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ONSdigital/dp-frontend-models/model"
 	"github.com/ONSdigital/dp-frontend-renderer/config"
 	"github.com/ONSdigital/go-ns/render"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 //Handler resolves the rendering of a specific pagem with a given model and template name
@@ -20,7 +20,7 @@ func Handler(w http.ResponseWriter, req *http.Request, page interface{}, page2 *
 		render.JSON(w, 400, model.ErrorResponse{
 			Error: err.Error(),
 		})
-		log.Event(ctx, "failed to read request body", log.Error(err), log.ERROR)
+		log.Error(ctx, "failed to read request body", err)
 		return
 	}
 
@@ -31,7 +31,7 @@ func Handler(w http.ResponseWriter, req *http.Request, page interface{}, page2 *
 		render.JSON(w, 400, model.ErrorResponse{
 			Error: err.Error(),
 		})
-		log.Event(ctx, "failed to unmarshal request body to page", log.Error(err), log.ERROR)
+		log.Error(ctx, "failed to unmarshal request body to page", err)
 		return
 	}
 
@@ -42,14 +42,14 @@ func Handler(w http.ResponseWriter, req *http.Request, page interface{}, page2 *
 	page2.PatternLibraryAssetsPath = cfg.PatternLibraryAssetsPath
 	page2.SiteDomain = cfg.SiteDomain
 
-	log.Event(ctx, "rendered template", log.Data{"template": templateName}, log.INFO)
+	log.Info(ctx, "rendered template", log.Data{"template": templateName})
 
 	err = render.HTML(w, 200, templateName, page)
 	if err != nil {
 		render.JSON(w, 500, model.ErrorResponse{
 			Error: err.Error(),
 		})
-		log.Event(ctx, "failed to render template", log.Error(err), log.ERROR)
+		log.Error(ctx, "failed to render template", err)
 		return
 	}
 }

--- a/render/helpers.go
+++ b/render/helpers.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/ONSdigital/go-ns/common"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/c2h5oh/datasize"
 	"github.com/gosimple/slug"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
@@ -45,7 +45,7 @@ func InitLocaleBundle() (*i18n.Bundle, error) {
 		filePath := "locales/active." + locale + ".toml"
 		asset, err := assets.Asset(filePath)
 		if err != nil {
-			log.Event(nil, "failed to get locale file", log.Error(err), log.ERROR)
+			log.Error(nil, "failed to get locale file", err)
 		}
 		bundle.ParseMessageFileBytes(asset, filePath)
 	}
@@ -71,7 +71,7 @@ func SafeHTML(s string) template.HTML {
 func DateFormat(s string) template.HTML {
 	t, err := time.Parse(time.RFC3339, s)
 	if err != nil {
-		log.Event(nil, "failed to parse time", log.Error(err), log.ERROR)
+		log.Error(nil, "failed to parse time", err)
 		return template.HTML(s)
 	}
 	localiseTime(&t)
@@ -81,7 +81,7 @@ func DateFormat(s string) template.HTML {
 func DateFormatYYYYMMDD(s string) template.HTML {
 	t, err := time.Parse(time.RFC3339, s)
 	if err != nil {
-		log.Event(nil, "failed to parse time", log.Error(err), log.ERROR)
+		log.Error(nil, "failed to parse time", err)
 		return template.HTML(s)
 	}
 	localiseTime(&t)
@@ -91,7 +91,7 @@ func DateFormatYYYYMMDD(s string) template.HTML {
 func localiseTime(t *time.Time) time.Time {
 	tz, err := time.LoadLocation("Europe/London")
 	if err != nil {
-		log.Event(nil, "failed to load time zone location", log.Error(err), log.ERROR)
+		log.Error(nil, "failed to load time zone location", err)
 		return *t
 	}
 	return t.In(tz)
@@ -200,7 +200,7 @@ func Markdown(md string) template.HTML {
 func Localise(key string, language string, plural int, templateArguments ...string) string {
 	if key == "" {
 		err := fmt.Errorf("key " + key + " not found in locale file")
-		log.Event(nil, "no locale look up key provided", log.Error(err), log.ERROR)
+		log.Error(nil, "no locale look up key provided", err)
 		return ""
 	}
 	if language == "" {
@@ -256,7 +256,7 @@ func DomainSetLang(domain string, uri string, language string) string {
 	domainWithTranslation := ""
 	if !languageSupported {
 		err := fmt.Errorf("Language: " + language + " is not supported resolving to " + common.DefaultLang)
-		log.Event(nil, "language fail", log.Error(err), log.ERROR)
+		log.Error(nil, "language fail", err)
 	}
 	if language == common.DefaultLang || !languageSupported {
 		domainWithTranslation = "https://www." + strippedURL

--- a/service/service.go
+++ b/service/service.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/go-ns/handlers/requestID"
 	"github.com/ONSdigital/go-ns/render"
-	"github.com/ONSdigital/log.go/log"
+	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/pat"
 	"github.com/justinas/alice"
 	unrolled "github.com/unrolled/render"
@@ -23,7 +23,7 @@ import (
 func Run(ctx context.Context, cfg *config.Config, taxonomyRedirects map[string]string, hc *healthcheck.HealthCheck) *http.Server {
 
 	// Override default renderer with service assets
-	log.Event(ctx, "overriding default renderer with service assets", log.INFO)
+	log.Info(ctx, "overriding default renderer with service assets")
 	render.Renderer = unrolled.New(unrolled.Options{
 		Asset:         assets.Asset,
 		AssetNames:    assets.AssetNames,
@@ -74,7 +74,7 @@ func Run(ctx context.Context, cfg *config.Config, taxonomyRedirects map[string]s
 	// Start the HTTP server in a new go routine
 	go func() {
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Event(ctx, "error starting http server", log.ERROR, log.Error(err))
+			log.Error(ctx, "error starting http server", err)
 		}
 	}()
 


### PR DESCRIPTION
### What

Update log.go requirement to v2 in go.mod and imports.
Update logging statements to format that can be parsed by
elastisearch, for example:

```go
log.Event(ctx, string, log.FATAL, log.Error(something1), something2)
	-> log.Fatal(ctx, string, something1, something2)

log.Event(ctx, string, log.ERROR log.Error(something1), something2)
	-> log.Error(ctx, string, something1, something2)

log.Event(ctx, string, log.INFO, something)
	-> log.Info(ctx, string, something)

log.Event(ctx, string, log.WARN, log.Error(something), something2)
	-> log.Warn(ctx, string, log.FormatErrors([]string{something}), something2)
```

These changes needed to allow error logs to be properly viewed in
kibana - currently any logs containing log.Error(err) do not end up in
Elasticsearch index and hence not viewable in Kibana.

### How to review

Check for calls to log. that do not use the new syntax
Check code builds and runs with make test
Run with make debug and check log output is as required for elastisearch / kibana

### Who can review

Anyone who isn't Vivian Allen and who understands the logging systems.