### PR TITLE
Fix dimension names being chopped off

### DIFF
--- a/assets/templates/dataset-filter/filter-overview.tmpl
+++ b/assets/templates/dataset-filter/filter-overview.tmpl
@@ -28,17 +28,17 @@
                                     <div class="col--lg-56 min-height--10 padding-left-sm--0 padding-left-md--1">
                                         {{$length := len .AddedCategories}}{{$categories := .AddedCategories}}
                                         <div class="col col--md-8 col--lg-8 min-height--4">
-                                            <a class="{{if eq .Link.Label "Edit"}}filter-overview__link--edit{{else}}filter-overview__link--add{{end}}" href="{{.Link.URL}}">
+                                            <a class="{{if eq .Link.Label "Edit"}}filter-overview__link--edit padding-top-sm--3{{else}}filter-overview__link--add padding-top-sm--2{{end}}" href="{{.Link.URL}}">
                                                 <span class="line-height--32 dimension-button {{if eq .Link.Label "Add"}}btn btn--tertiary margin-left-md--2 margin-left-sm--1 {{else}}margin-left-md--3 margin-left-sm--2 {{end}} font-weight-700 ">{{.Link.Label}}
                                                     <span class="visuallyhidden">
                                                         {{if gt $length 0}}by {{end}}{{.Filter}}</span></span></a>
                                         </div>
-                                        <div class="dimension-name col col--md-11 col--lg-14 margin-left-sm--6 height-sm--3 height-md--6 overflow--hidden margin-top-md--3 margin-bottom-sm--2">
+                                        <div class="dimension-name col col--md-11 col--lg-14 margin-left-sm--6 overflow--hidden height--10 flex flex-direction--column content-center padding-top-sm--3">
                                             <strong>
                                                 <span class="js-filter-option-label font-size--18 line-height--32">{{.Filter}}</span></strong>
                                         </div>
                                         <div id="number-added-{{slug .Filter}}" class="col col--md-20 col--lg-30">
-                                            <div class="font-size--18 line-height--32 height-sm--3 height-md--10 nowrap-sm vertical-align-middle margin-left-sm--4 list--ellipses-sm overflow--hidden">
+                                            <div class="font-size--18 line-height--32 height-sm--5 height-md--10 nowrap-sm vertical-align-middle margin-left-sm--4 list--ellipses-sm overflow--hidden">
                                                 <div class="height-sm--3 max-height-md--9 vertical-align-middle__contents--md list--ellipses-md">
                                                     <ul class="list list--pipe-seperated list--pipe-seperated-ellipses">
                                                         <li class="line-height--32 list--no-separator">

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/f80be2c"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/c690dcd"
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
### What

- Refactored dimension names container to use `flex`. Multiline titles now fill the container and align correctly.
- Other design tweaks to prevent unnecessary type trim 

_...before_
<img width="949" alt="Screenshot 2021-07-02 at 13 51 50" src="https://user-images.githubusercontent.com/19624419/124277244-bc621f80-db3c-11eb-985c-e359d1a0eb08.png">
<img width="691" alt="Screenshot 2021-07-02 at 13 58 04" src="https://user-images.githubusercontent.com/19624419/124278114-c3d5f880-db3d-11eb-82a8-1d0887b7a3e0.png">
<img width="913" alt="Screenshot 2021-07-05 at 08 44 38" src="https://user-images.githubusercontent.com/19624419/124435876-57414080-dd6d-11eb-958c-09a8fdc61f19.png">

_...after_
<img width="913" alt="Screenshot 2021-07-05 at 08 47 51" src="https://user-images.githubusercontent.com/19624419/124436290-b737e700-dd6d-11eb-89ea-c54bfb6a7bca.png">
<img width="691" alt="Screenshot 2021-07-02 at 14 00 35" src="https://user-images.githubusercontent.com/19624419/124278381-17484680-db3e-11eb-9f12-2cb8dbfaa74c.png">
<img width="932" alt="Screenshot 2021-07-02 at 13 53 25" src="https://user-images.githubusercontent.com/19624419/124277404-e9163700-db3c-11eb-950a-695141074856.png">

### How to review

Requires CMD journey to be setup locally
Sense check
Pictures show changes ^

### Who can review

Anyone but me
