### PR TITLE
use alt text and remove title

### DIFF
--- a/assets/templates/homepage/census-tile.tmpl
+++ b/assets/templates/homepage/census-tile.tmpl
@@ -2,13 +2,12 @@
     <header class="margin-top--1">
         <h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0">
                 {{if eq .Language "en" }}
-                    <img src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape.svg" alt="" class="header__svg-logo"
-                    xmlns="http://www.w3.org/2000/svg" focusable="false" width="209" height="40" viewBox="0 0 228 44" aria-labelledby="census-logo-en-alt">
+                    <img src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape.svg" alt="{{ localise "Census2021" .Language 1 }}" class="header__svg-logo"
+                    xmlns="http://www.w3.org/2000/svg" focusable="false" width="209" height="40" viewBox="0 0 228 44">
                 {{ else }}
-                    <img src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape-cy.svg" alt="" class="header__svg-logo"
-                    xmlns="http://www.w3.org/2000/svg" focusable="false" width="209" height="40" viewBox="0 0 228 44" aria-labelledby="census-logo-en-alt">
+                    <img src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape-cy.svg" alt="{{ localise "Census2021" .Language 1 }}" class="header__svg-logo"
+                    xmlns="http://www.w3.org/2000/svg" focusable="false" width="209" height="40" viewBox="0 0 228 44">
                 {{ end }}
-                <title id="census-logo-en-alt">{{ localise "Census2021" .Language 1 }}</title>
                 </img>
         </h2>
     </header>

--- a/assets/templates/partials/banners/census-tile-sm.tmpl
+++ b/assets/templates/partials/banners/census-tile-sm.tmpl
@@ -2,13 +2,12 @@
     <header class="margin-top--1">
         <h2 class="margin-top--0 margin-right--0 margin-bottom--0 margin-left--0">
                 {{if eq .Language "en" }}
-                    <img src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape.svg" alt="" class="header__svg-logo"
-                    xmlns="http://www.w3.org/2000/svg" focusable="false" width="209" height="40" viewBox="0 0 228 44" aria-labelledby="census-logo-en-alt">
+                    <img src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape.svg" alt="{{ localise "Census2021" .Language 1 }}" class="header__svg-logo"
+                    xmlns="http://www.w3.org/2000/svg" focusable="false" width="209" height="40" viewBox="0 0 228 44">
                 {{ else }}
-                    <img src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape-cy.svg" alt="" class="header__svg-logo"
-                    xmlns="http://www.w3.org/2000/svg" focusable="false" width="209" height="40" viewBox="0 0 228 44" aria-labelledby="census-logo-en-alt">
+                    <img src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-white-landscape-cy.svg" alt="{{ localise "Census2021" .Language 1 }}" class="header__svg-logo"
+                    xmlns="http://www.w3.org/2000/svg" focusable="false" width="209" height="40" viewBox="0 0 228 44">
                 {{ end }}
-                <title id="census-logo-en-alt">{{ localise "Census2021" .Language 1 }}</title>
                 </img>
         </h2>
     </header>


### PR DESCRIPTION
### What

Removed `title` and `id`. Used `alt` instead. 

### How to review

See that `alt` displays the correct information ("Census 2021")

https://trello.com/c/g79Z7jV2/803-census-logo-id-parsing-error

<img width="1043" alt="Screenshot 2021-07-20 at 10 28 12" src="https://user-images.githubusercontent.com/16807393/126298692-379a488f-8541-4683-a9a3-ba1aa3339227.png">


<img width="1080" alt="Screenshot 2021-07-20 at 10 30 04" src="https://user-images.githubusercontent.com/16807393/126299033-9157a2e0-64c7-4e7c-a99d-b0e1a872b668.png">

**Small viewport:** 
<img width="1024" alt="Screenshot 2021-07-20 at 13 13 17" src="https://user-images.githubusercontent.com/16807393/126322747-c0077ec0-fb5f-4e9f-8718-ff9b77e870ca.png">

**Medium viewport**
<img width="1034" alt="Screenshot 2021-07-20 at 13 13 58" src="https://user-images.githubusercontent.com/16807393/126322785-03f92ea4-35eb-4f16-8233-f64553baa88e.png">

**Large viewport**
<img width="1432" alt="Screenshot 2021-07-20 at 13 21 15" src="https://user-images.githubusercontent.com/16807393/126322880-3f6bf261-5f5f-4e07-ab09-c69f4d3f971e.png">




### Who can review

Anyone but me. 
