### PR TITLE
allow html for search highlighting

### DIFF
--- a/assets/templates/search/results.tmpl
+++ b/assets/templates/search/results.tmpl
@@ -17,7 +17,7 @@
                             data-gtm-search-result-url="{{ .URI }}"
                             data-gtm-search-result-release-date="{{ dateFormatYYYYMMDDNoSlash .Description.ReleaseDate }}"
                             >
-                                {{ .Description.Title }}
+                                {{ .Description.Title | safeHTML }}
                             </a>
                         </h3>
                         <p class="search-results__meta font-size--16">
@@ -26,15 +26,15 @@
                             {{ localise "ReleasedOn" $lang 1 }} {{dateFormat .Description.ReleaseDate}}
                         </p>
                         <div class="search-results__summary font-size--16">
-                            {{ .Description.Summary}}
+                            {{ .Description.Summary | safeHTML }}
                         </div>
                         {{ if .Description.Keywords }}
                             {{ $numberOfKeywords := len .Description.Keywords }}
                             {{ if gt $numberOfKeywords 0}}
                                 <p class="search-results__keywords font-size--16">
-                                    {{ localise "Keywords" $lang 4 }}: 
+                                    {{ localise "Keywords" $lang 4 }}:
                                     {{ range $i, $el := .Description.Keywords }}
-                                        {{$el}}{{ if notLastItem $numberOfKeywords $i }},{{end}}
+                                        {{$el | safeHTML }}{{ if notLastItem $numberOfKeywords $i }},{{end}}
                                     {{end}}
                                 </p>
                             {{end}}

--- a/render/handler.go
+++ b/render/handler.go
@@ -3,13 +3,12 @@ package render
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
-	"net/http"
-
 	"github.com/ONSdigital/dp-frontend-models/model"
 	"github.com/ONSdigital/dp-frontend-renderer/config"
 	"github.com/ONSdigital/go-ns/render"
 	"github.com/ONSdigital/log.go/v2/log"
+	"io/ioutil"
+	"net/http"
 )
 
 //Handler resolves the rendering of a specific pagem with a given model and template name
@@ -43,7 +42,6 @@ func Handler(w http.ResponseWriter, req *http.Request, page interface{}, page2 *
 	page2.SiteDomain = cfg.SiteDomain
 
 	log.Info(ctx, "rendered template", log.Data{"template": templateName})
-
 	err = render.HTML(w, 200, templateName, page)
 	if err != nil {
 		render.JSON(w, 500, model.ErrorResponse{


### PR DESCRIPTION
### What

Add `safeHTML` to search results to allow for highlighting

### How to review
Must have the following services running in order to view this change: 
- `dp-search-api`
- `dp-frontend-search-controller`
-  set `SearchRoutesEnabled` to `true` in the config of the `dp-frontend-router`

See that tests pass. Pull branch and see that new yellow highlighting `<em class="highlighting">` is applied to search results. Should look like the image below. 
<img width="1096" alt="Screenshot 2021-09-22 at 08 55 24" src="https://user-images.githubusercontent.com/16807393/134304954-58f26c90-2ce1-467c-b125-c63992f8a46d.png">



### Who can review

Anyone but me. 
