### PR TITLE
Bug/homepage not displaying cookie banner

### DIFF
--- a/assets/locales/active.cy.toml
+++ b/assets/locales/active.cy.toml
@@ -358,6 +358,149 @@ one = "Rhybuddion ebost"
 description = "Open Government Licence v3.0"
 one = "Mae'r holl gynnwys ar gael o dan delerau'r <a class=\"icon--hide\" href=\"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\" target=\"_blank\">Open Government Licence v3.0</a> <span class=\"icon icon-external--light-small\"></span>, ac eithrio lle y nodir fel arall"
 
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+# Cookies page
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+[CookiesOnONS]
+description = "Cookies on ONS.GOV.UK"
+one = "Cookies on ONS.GOV.UK"
+
+[CookiesP1]
+description = "Cookies are files saved on your phone, tablet or computer when you visit a website."
+one = "Cookies are files saved on your phone, tablet or computer when you visit a website."
+
+[CookiesP2]
+description = "We use cookies to store information about how you use the ons.gov.uk website, such as the pages you visit."
+one = "We use cookies to store information about how you use the ons.gov.uk website, such as the pages you visit."
+
+[CookiesSettings]
+description = "Cookie settings"
+one = "Cookie settings"
+
+[CookiesNoJSWarn1]
+description = "We use JavaScript to set most of our cookies. It appears that JavaScript is not running on your browser, so we are unable to change your cookie settings. To change this you can try:"
+one = "We use JavaScript to set most of our cookies. It appears that JavaScript is not running on your browser, so we are unable to change your cookie settings. To change this you can try:"
+
+[CookiesNoJSWarn2]
+description = "Without JavaScript we will only set cookies that are strictly necessary."
+one = "Without JavaScript we will only set cookies that are strictly necessary."
+
+[CookiesNoJSOpt1]
+description = "reloading the page"
+one = "reloading the page"
+
+[CookiesNoJSOpt2]
+description = "turning on JavaScript in your browser"
+one = "turning on JavaScript in your browser"
+
+[CookiesSettingsP1]
+description = "We use 2 types of cookie. You can choose which cookies you're happy for us to use."
+one = "We use 2 types of cookie. You can choose which cookies you're happy for us to use."
+
+[CookiesUsage]
+description = "Cookies that measure website use"
+one = "Cookies that measure website use"
+
+[CookiesUsageP1]
+description = "We use Google Analytics and Hotjar to measure how you use the website so we can improve it based on user needs. Google Analytics and Hotjar set cookies that store anonymised information about:"
+one = "We use Google Analytics and Hotjar to measure how you use the website so we can improve it based on user needs. Google Analytics and Hotjar set cookies that store anonymised information about:"
+
+[CookiesUsageBP1]
+description = "how you got to the site"
+one = "how you got to the site"
+
+[CookiesUsageBP2]
+description = "the pages you visit on ons.gov.uk and how long you spend on each page"
+one = "the pages you visit on ons.gov.uk and how long you spend on each page"
+
+[CookiesUsageBP3]
+description = "what you click on while you are visiting the site"
+one = "what you click on while you are visiting the site"
+
+[CookiesUsageBP4]
+description = "the way in which you interact with a page"
+one = "the way in which you interact with a page"
+
+[CookiesUsageBP5]
+description = "whether you have participated in a Hotjar survey"
+one = "whether you have participated in a Hotjar survey"
+
+[CookiesUsageP2]
+description = "We do not allow Google or Hotjar to use or share the data about how you use this site."
+one = "We do not allow Google or Hotjar to use or share the data about how you use this site."
+
+[CookiesEssential]
+description = "Strictly necessary cookies"
+one = "Strictly necessary cookies"
+
+[CookiesEssentialP1]
+description = "These essential cookies do things like remember your progress through a form."
+one = "These essential cookies do things like remember your progress through a form."
+
+[CookiesEssentialP2]
+description = "They always need to be on to allow the website to function properly."
+one = "They always need to be on to allow the website to function properly."
+
+[CookiesEssentialP3]
+description = "Find out more about cookies on ons.gov.uk"
+one = "<a href=\"/help/cookies\">Find out more about cookies on ons.gov.uk</a>"
+
+[On]
+description = "On"
+one = "On"
+
+[Off]
+description = "Off"
+one = "Off"
+
+[SaveChanges]
+description = "Save changes"
+one = "Save change"
+two = "Save changes"
+few = "Save changes"
+other = "Save changes"
+
+[CookiesBannerHeading]
+description = "Tell us whether you accept cookies"
+one = "Tell us whether you accept cookies"
+
+[CookiesBannerOverview]
+description = "We would like to <a href=\"/cookies\">use cookies to collect information</a> about how you use <strong>ons.gov.uk</strong>."
+one = "We would like to <a href=\"/cookies\">use cookies to collect information</a> about how you use <strong>ons.gov.uk</strong>."
+
+[CookiesBannerWhyWeUse]
+description = "We use this information to make the website work as well as possible and improve our services."
+one = "We use this information to make the website work as well as possible and improve our services."
+
+[CookiesBannerAcceptAllAction]
+description = "Accept all cookies"
+one = "Accept all cookies"
+
+[CookiesBannerSetPreferencesAction]
+description = "Set cookie preferences"
+one = "Set cookie preference"
+other = "Set cookie preferences"
+
+[CookiesBannerSuccess]
+description = "You’ve accepted all cookies. You can <a href=\"/cookies\">change your cookie settings</a> at any time."
+one = "You’ve accepted all cookies. You can <a href=\"/cookies\">change your cookie settings</a> at any time."
+
+[CookiesBannerHide]
+description = "Hide"
+one = "Hide"
+
+[CookiesPreferencesSaved]
+description = "We have saved your cookie preferences."
+one = "We have saved your cookie preference."
+other = "We have saved your cookie preferences."
+
+[CookiesPreferencesSavedAmend]
+description = "Should you ever wish to amend them, visit <strong><a href=\"/cookies\">ons.gov.uk/cookies</a></strong>."
+one = "Should you ever wish to amend them, visit <strong><a href=\"/cookies\">ons.gov.uk/cookies</a></strong>."
+other = "Should you ever wish to amend them, visit <strong><a href=\"/cookies\">ons.gov.uk/cookies</a></strong>."
+
+
 [Covid19BannerTitle]
 description = "Coronafeirws (COVID-19)"
 one = "Coronafeirws (COVID-19)"

--- a/assets/locales/active.en.toml
+++ b/assets/locales/active.en.toml
@@ -350,6 +350,147 @@ one = "Email alerts"
 description = "Open Government Licence v3.0"
 one = "All content is available under the <a class=\"icon--hide\" href=\"http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\" target=\"_blank\">Open Government Licence v3.0</a> <span class=\"icon icon-external--light-small\"></span>, except where otherwise stated"
 
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+# Cookies page
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+[CookiesOnONS]
+description = "Cookies on ONS.GOV.UK"
+one = "Cookies on ONS.GOV.UK"
+
+[CookiesP1]
+description = "Cookies are files saved on your phone, tablet or computer when you visit a website."
+one = "Cookies are files saved on your phone, tablet or computer when you visit a website."
+
+[CookiesP2]
+description = "We use cookies to store information about how you use the ons.gov.uk website, such as the pages you visit."
+one = "We use cookies to store information about how you use the ons.gov.uk website, such as the pages you visit."
+
+[CookiesSettings]
+description = "Cookie settings"
+one = "Cookie settings"
+
+[CookiesNoJSWarn1]
+description = "We use JavaScript to set most of our cookies. It appears that JavaScript is not running on your browser, so we are unable to change your cookie settings. To change this you can try:"
+one = "We use JavaScript to set most of our cookies. It appears that JavaScript is not running on your browser, so we are unable to change your cookie settings. To change this you can try:"
+
+[CookiesNoJSWarn2]
+description = "Without JavaScript we will only set cookies that are strictly necessary."
+one = "Without JavaScript we will only set cookies that are strictly necessary."
+
+[CookiesNoJSOpt1]
+description = "reloading the page"
+one = "reloading the page"
+
+[CookiesNoJSOpt2]
+description = "turning on JavaScript in your browser"
+one = "turning on JavaScript in your browser"
+
+[CookiesSettingsP1]
+description = "We use 2 types of cookie. You can choose which cookies you're happy for us to use."
+one = "We use 2 types of cookie. You can choose which cookies you're happy for us to use."
+
+[CookiesUsage]
+description = "Cookies that measure website use"
+one = "Cookies that measure website use"
+
+[CookiesUsageP1]
+description = "We use Google Analytics and Hotjar to measure how you use the website so we can improve it based on user needs. Google Analytics and Hotjar set cookies that store anonymised information about:"
+one = "We use Google Analytics and Hotjar to measure how you use the website so we can improve it based on user needs. Google Analytics and Hotjar set cookies that store anonymised information about:"
+
+[CookiesUsageBP1]
+description = "how you got to the site"
+one = "how you got to the site"
+
+[CookiesUsageBP2]
+description = "the pages you visit on ons.gov.uk and how long you spend on each page"
+one = "the pages you visit on ons.gov.uk and how long you spend on each page"
+
+[CookiesUsageBP3]
+description = "what you click on while you are visiting the site"
+one = "what you click on while you are visiting the site"
+
+[CookiesUsageBP4]
+description = "the way in which you interact with a page"
+one = "the way in which you interact with a page"
+
+[CookiesUsageBP5]
+description = "whether you have participated in a Hotjar survey"
+one = "whether you have participated in a Hotjar survey"
+
+[CookiesUsageP2]
+description = "We do not allow Google or Hotjar to use or share the data about how you use this site."
+one = "We do not allow Google or Hotjar to use or share the data about how you use this site."
+
+[CookiesEssential]
+description = "Strictly necessary cookies"
+one = "Strictly necessary cookies"
+
+[CookiesEssentialP1]
+description = "These essential cookies do things like remember your progress through a form."
+one = "These essential cookies do things like remember your progress through a form."
+
+[CookiesEssentialP2]
+description = "They always need to be on to allow the website to function properly."
+one = "They always need to be on to allow the website to function properly."
+
+[CookiesEssentialP3]
+description = "Find out more about cookies on ons.gov.uk"
+one = "<a href=\"/help/cookies\">Find out more about cookies on ons.gov.uk</a>"
+
+[CookiesPreferencesSaved]
+description = "We have saved your cookie preferences."
+one = "We have saved your cookie preference."
+other = "We have saved your cookie preferences."
+
+[CookiesPreferencesSavedAmend]
+description = "Should you ever wish to amend them, visit <strong><a href=\"/cookies\">ons.gov.uk/cookies</a></strong>."
+one = "Should you ever wish to amend them, visit <strong><a href=\"/cookies\">ons.gov.uk/cookies</a></strong>."
+other = "Should you ever wish to amend them, visit <strong><a href=\"/cookies\">ons.gov.uk/cookies</a></strong>."
+
+[On]
+description = "On"
+one = "On"
+
+[Off]
+description = "Off"
+one = "Off"
+
+[SaveChanges]
+description = "Save changes"
+one = "Save change"
+other = "Save changes"
+
+[CookiesBannerHeading]
+description = "Tell us whether you accept cookies"
+one = "Tell us whether you accept cookies"
+
+[CookiesBannerOverview]
+description = "We would like to <a href=\"/cookies\">use cookies to collect information</a> about how you use <strong>ons.gov.uk</strong>."
+one = "We would like to <a href=\"/cookies\">use cookies to collect information</a> about how you use <strong>ons.gov.uk</strong>."
+
+[CookiesBannerWhyWeUse]
+description = "We use this information to make the website work as well as possible and improve our services."
+one = "We use this information to make the website work as well as possible and improve our services."
+
+[CookiesBannerAcceptAllAction]
+description = "Accept all cookies"
+one = "Accept all cookies"
+
+[CookiesBannerSetPreferencesAction]
+description = "Set cookie preferences"
+one = "Set cookie preference"
+other = "Set cookie preferences"
+
+[CookiesBannerSuccess]
+description = "You’ve accepted all cookies. You can <a href=\"/cookies\">change your cookie settings</a> at any time."
+one = "You’ve accepted all cookies. You can <a href=\"/cookies\">change your cookie settings</a> at any time."
+
+[CookiesBannerHide]
+description = "Hide"
+one = "Hide"
+
+
 [Covid19BannerTitle]
 description = "Coronavirus (COVID-19)"
 one = "Coronavirus (COVID-19)"

--- a/assets/templates/cookies-preferences.tmpl
+++ b/assets/templates/cookies-preferences.tmpl
@@ -1,0 +1,77 @@
+<div class="page-intro background--gallery">
+    <div class="wrapper">
+        <div class="col-wrap">
+            <div class="col margin-top--1">
+                {{ template "partials/breadcrumb" . }}
+                <h1 class="page-intro__title margin-bottom--4 font-weight-700">
+                    {{ localise "CookiesOnONS" .Language 1}}
+                </h1>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="wrapper adjust-font-size--18">
+    {{if .PreferencesUpdated }}
+        <div class="min-height--10 margin-top--4 cookies-banner__preferences-success">
+            <div class="font-size--18 cookies-banner__preferences-success-body">
+                <h2 class="font-weight-700 margin-top--2">{{ localise "CookiesPreferencesSaved" .Language 4 }}</h2>
+                <p class="padding-bottom--0 margin-top--1 margin-bottom--1">{{ localise "CookiesPreferencesSavedAmend" .Language 4 | safeHTML }}</p>
+            </div>
+        </div>
+    {{end}}
+
+    <p>{{ localise "CookiesP1" .Language 1}}</p>
+
+    <p>{{ localise "CookiesP2" .Language 1}}</p>
+
+    <h2 class="font-weight-700">{{ localise "CookiesSettings" .Language 1}}</h2>
+
+    <div class="cookies-no-js">
+        <p> {{ localise "CookiesNoJSWarn1" .Language 1}} </p>
+        <ul class="margin-left--1">
+            <li>{{ localise "CookiesNoJSOpt1" .Language 1}}</li>
+            <li>{{ localise "CookiesNoJSOpt2" .Language 1}}</li>
+        </ul>
+        <p> {{ localise "CookiesNoJSWarn2" .Language 1}} </p>
+    </div>
+
+    <p class="cookies-js hidden">{{ localise "CookiesSettingsP1" .Language 1}}</p>
+
+    <form action="/cookies" method="post">
+        <fieldset class="margin-bottom--6 cookies-js hidden">
+            <legend class="font-weight-700 font-size--21">{{ localise "CookiesUsage" .Language 1}}</legend>
+            <p>{{ localise "CookiesUsageP1" .Language 1}}</p>
+            <ul class="margin-left--1">
+                <li>{{ localise "CookiesUsageBP1" .Language 1}}</li>
+                <li>{{ localise "CookiesUsageBP2" .Language 1}}</li>
+                <li>{{ localise "CookiesUsageBP3" .Language 1}}</li>
+                <li>{{ localise "CookiesUsageBP4" .Language 1}}</li>
+                <li>{{ localise "CookiesUsageBP5" .Language 1}}</li>
+            </ul>
+            <p>{{ localise "CookiesUsageP2" .Language 1}}</p>
+
+            <div>
+                <div class="radio margin-top--1 radio--inline">
+                    <input class="radio__input"  type="radio" name="cookie-policy-usage" id="usage-on" value="true" {{ if eq .CookiesPolicy.Usage true }}checked{{ end }}/>
+                    <label class="radio__label" for="usage-on">{{ localise "On" .Language 1}}</label>
+                </div>
+                <div class="radio margin-top--1 radio--inline">
+                    <input class="radio__input"  type="radio" name="cookie-policy-usage" id="usage-off" value="false" {{ if eq .CookiesPolicy.Usage false }}checked{{ end }} />
+                    <label class="radio__label" for="usage-off">{{ localise "Off" .Language 1}}</label>
+                </div>
+            </div>
+        </fieldset>
+    
+        <h3 class="font-weight-700 margin-top--2">{{ localise "CookiesEssential" .Language 1}}</h3>
+
+        <p>{{ localise "CookiesEssentialP1" .Language 1}}</p>
+
+        <p>{{ localise "CookiesEssentialP2" .Language 1}}</p>
+        
+        <p>{{ localise "CookiesEssentialP3" .Language 1 | safeHTML }}</p>
+
+        <button class="btn btn--primary btn--thick btn--wide btn--big btn--focus margin-top--2 margin-right--2 font-weight-700 font-size--17 text-wrap cookies-js hidden" type="submit">{{ localise "SaveChanges" .Language 4}}</button>
+
+    </form>
+</div>

--- a/assets/templates/main.tmpl
+++ b/assets/templates/main.tmpl
@@ -39,6 +39,10 @@
   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MBCBVQS"
                     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
+    {{ if (ne .FeatureFlags.HideCookieBanner true)}}
+      {{ template "partials/banners/cookies" . }}
+    {{ end }}
+
     {{ template "partials/header" . }}
 
     <main id="main" role="main" tabindex="-1">

--- a/assets/templates/partials/banners/cookies.tmpl
+++ b/assets/templates/partials/banners/cookies.tmpl
@@ -1,4 +1,4 @@
-<section>
+<section data-nosnippet>
     <form action="/cookies/accept-all" method="GET" id="global-cookie-message" class="cookies-banner cookies-banner--hidden js-cookies-banner-form clearfix"
                 aria-label="cookie banner">
         <div class="cookies-banner__wrapper wrapper js-cookies-banner-inform">

--- a/assets/templates/partials/banners/cookies.tmpl
+++ b/assets/templates/partials/banners/cookies.tmpl
@@ -1,0 +1,34 @@
+<section>
+    <form action="/cookies/accept-all" method="GET" id="global-cookie-message" class="cookies-banner cookies-banner--hidden js-cookies-banner-form clearfix"
+                aria-label="cookie banner">
+        <div class="cookies-banner__wrapper wrapper js-cookies-banner-inform">
+            <div>
+                <div class="cookies-banner__message adjust-font-size--18">
+                    <h1 class="cookies-banner__heading font-size--h3">{{ localise "CookiesBannerHeading" .Language 1 }}</h1>
+                    <p class="cookies-banner__body">{{ localise "CookiesBannerOverview" .Language 1 | safeHTML }}</p>
+                    <p class="cookies-banner__body">{{ localise "CookiesBannerWhyWeUse" .Language 1 }}</p>
+                </div>
+                <div class="cookies-banner__buttons">
+                    <div class="nojs--hide cookies-banner__button cookies-banner__button--accept">
+                        <button class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies" data-gtm-accept-cookies="true" type="submit">{{ localise "CookiesBannerAcceptAllAction" .Language 1 }}</button>
+                    </div>
+                    <div class="cookies-banner__button">
+                        <a role="button" href="/cookies" class="btn btn--full-width btn--primary btn--focus margin-right--2 font-weight-700 font-size--17 text-wrap js-accept-cookies">{{ localise "CookiesBannerSetPreferencesAction" .Language 4 }}</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="hidden js-cookies-banner-confirmation" tabindex="-1">
+            <div class="cookies-banner__wrapper wrapper">
+                <div class="col">
+                    <div class="cookies-banner__message adjust-font-size--18">
+                        <p class="cookies-banner__confirmation-message">
+                            {{ localise "CookiesBannerSuccess" .Language 1 | safeHTML }}
+                            <button type="button" class="cookies-banner__button--hide js-hide-cookies-banner">{{ localise "CookiesBannerHide" .Language 1 }}</button>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+</section>

--- a/handlers/cookies/handler.go
+++ b/handlers/cookies/handler.go
@@ -1,0 +1,19 @@
+package cookies
+
+import (
+	"net/http"
+
+	"github.com/ONSdigital/dp-frontend-renderer/config"
+
+	"github.com/ONSdigital/dp-frontend-models/model/cookiespreferences"
+	"github.com/ONSdigital/dp-frontend-renderer/render"
+)
+
+//Handler ...
+func Handler(cfg config.Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		var page cookiespreferences.Page
+
+		render.Handler(w, req, &page, &page.Page, "cookies-preferences", nil, cfg)
+	}
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"github.com/ONSdigital/dp-frontend-renderer/config"
+	"github.com/ONSdigital/dp-frontend-renderer/handlers/cookies"
 	"github.com/ONSdigital/dp-frontend-renderer/handlers/dataset-filter/ageSelector"
 	"github.com/ONSdigital/dp-frontend-renderer/handlers/dataset-filter/filterOverview"
 	"github.com/ONSdigital/dp-frontend-renderer/handlers/dataset-filter/geography"
@@ -36,4 +37,5 @@ func Setup(router *pat.Router, cfg *config.Config, hc *healthcheck.HealthCheck) 
 	router.Post("/geography-homepage", geographyHomepage.Handler(*cfg))
 	router.Post("/geography-list", geographyList.Handler(*cfg))
 	router.Post("/geography-area", geographyArea.Handler(*cfg))
+	router.Post("/cookies-preferences", cookies.Handler(*cfg))
 }


### PR DESCRIPTION
### What
Trello card https://trello.com/c/1NbkONTs/961-homepage-is-not-displaying-the-cookie-banner

The cookies message has previously been removed from the homepage with a view to using dp-renderer, however the homepage has not yet been updated to use dp-renderer rather than dp-frontend-renderer. After some discussion a temporary solution was decided on of reinstating the old cookie. An HTML tag of "data-nosnippet" has been added to stop google from using the cookie message in the google search preview.

### How to review

- Check the code reverted to doesn't accidentally include anything unnecessary. 
- Check the cookie banner is loading locally.

### Who can review

Anyone.
