### PR TITLE
Added further processing if string recieved is long enough

### DIFF
--- a/render/helpers.go
+++ b/render/helpers.go
@@ -157,9 +157,11 @@ func DatePeriodFormat(s string) string {
 
 				if dateStart.After(dateEnd) {
 					dateEnd = dateEnd.AddDate(1, 0, 0)
+					s = dateStart.Format("Jan 2006")
+				} else {
+					s = dateStart.Format("Jan")
 				}
-
-				s = monthStart.Format("Jan 2006") + " - " + monthEnd.Format("Jan 2006")
+				s = s + " - " + dateEnd.Format("Jan 2006")
 			} else {
 				// YYYY[space] = 5 characters
 				postYearIndex := 5

--- a/render/helpers.go
+++ b/render/helpers.go
@@ -146,27 +146,25 @@ func DatePeriodFormat(s string) string {
 	// 3. Move year to end of string if present and insert a space
 	if err == nil {
 		// Not just displaying year but month as well
-		if len(s) > 5 {
-			// YYYY[space]DEC[space]-[space]JAN = 14 characters
-			if len(s) == 14 {
-				monthStart, _ := time.Parse("Jan", s[5:8])
-				monthEnd, _ := time.Parse("Jan", s[11:])
+		// YYYY[space]DEC[space]-[space]JAN = 14 characters
+		if len(s) == 14 {
+			monthStart, _ := time.Parse("Jan", s[5:8])
+			monthEnd, _ := time.Parse("Jan", s[11:])
 
-				dateStart := monthStart.AddDate(year, 0, 0)
-				dateEnd := monthEnd.AddDate(year, 0, 0)
+			dateStart := monthStart.AddDate(year, 0, 0)
+			dateEnd := monthEnd.AddDate(year, 0, 0)
 
-				if dateStart.After(dateEnd) {
-					dateEnd = dateEnd.AddDate(1, 0, 0)
-					s = dateStart.Format("Jan 2006")
-				} else {
-					s = dateStart.Format("Jan")
-				}
-				s = s + " - " + dateEnd.Format("Jan 2006")
-			} else if len(s) > 5 {
-				// YYYY[space] = 5 characters
-				postYearIndex := 5
-				s = s[postYearIndex:] + " " + s[:4]
+			if dateStart.After(dateEnd) {
+				dateEnd = dateEnd.AddDate(1, 0, 0)
+				s = dateStart.Format("Jan 2006")
+			} else {
+				s = dateStart.Format("Jan")
 			}
+			s = s + " - " + dateEnd.Format("Jan 2006")
+		} else if len(s) > 5 {
+			// YYYY[space] = 5 characters
+			postYearIndex := 5
+			s = s[postYearIndex:] + " " + s[:4]
 		}
 	}
 	// 4. Convert BLOCK CAPS to Title Caps

--- a/render/helpers.go
+++ b/render/helpers.go
@@ -141,28 +141,29 @@ func DatePeriodFormat(s string) string {
 		s = s[:Q4] + "Oct - Dec" + s[Q4EndIndex:]
 
 	}
+
+	year, err := strconv.Atoi(s[:4])
 	// 3. Move year to end of string if present and insert a space
-	if _, err := strconv.Atoi(s[:4]); err == nil {
+	if err == nil {
 		// Not just displaying year but month as well
 		if len(s) > 5 {
-			if len(s) < 14 {
-				// YYYY[space] = 5 characters
-				postYearIndex := 5
-				s = s[postYearIndex:] + " " + s[:4]
-			}
+			// YYYY[space]DEC[space]-[space]JAN = 14 characters
 			if len(s) == 14 {
-				year, _ := strconv.Atoi(s[:4])
 				monthStart, _ := time.Parse("Jan", s[5:8])
 				monthEnd, _ := time.Parse("Jan", s[11:])
 
-				if monthStart.After(monthEnd) {
-					monthEnd = monthEnd.AddDate(year+1, 0, 0)
-				} else {
-					monthEnd = monthEnd.AddDate(year, 0, 0)
+				dateStart := monthStart.AddDate(year, 0, 0)
+				dateEnd := monthEnd.AddDate(year, 0, 0)
+
+				if dateStart.After(dateEnd) {
+					dateEnd = dateEnd.AddDate(1, 0, 0)
 				}
-				monthStart = monthStart.AddDate(year, 0, 0)
 
 				s = monthStart.Format("Jan 2006") + " - " + monthEnd.Format("Jan 2006")
+			} else {
+				// YYYY[space] = 5 characters
+				postYearIndex := 5
+				s = s[postYearIndex:] + " " + s[:4]
 			}
 		}
 	}

--- a/render/helpers.go
+++ b/render/helpers.go
@@ -162,7 +162,7 @@ func DatePeriodFormat(s string) string {
 					s = dateStart.Format("Jan")
 				}
 				s = s + " - " + dateEnd.Format("Jan 2006")
-			} else {
+			} else if len(s) > 5 {
 				// YYYY[space] = 5 characters
 				postYearIndex := 5
 				s = s[postYearIndex:] + " " + s[:4]

--- a/render/helpers.go
+++ b/render/helpers.go
@@ -145,10 +145,25 @@ func DatePeriodFormat(s string) string {
 	if _, err := strconv.Atoi(s[:4]); err == nil {
 		// Not just displaying year but month as well
 		if len(s) > 5 {
-			// YYYY[space] = 5 characters
-			postYearIndex := 5
-			s = s[postYearIndex:] + " " + s[:4]
+			if len(s) < 14 {
+				// YYYY[space] = 5 characters
+				postYearIndex := 5
+				s = s[postYearIndex:] + " " + s[:4]
+			}
+			if len(s) == 14 {
+				year, _ := strconv.Atoi(s[:4])
+				monthStart, _ := time.Parse("Jan", s[5:8])
+				monthEnd, _ := time.Parse("Jan", s[11:])
 
+				if monthStart.After(monthEnd) {
+					monthEnd = monthEnd.AddDate(year+1, 0, 0)
+				} else {
+					monthEnd = monthEnd.AddDate(year, 0, 0)
+				}
+				monthStart = monthStart.AddDate(year, 0, 0)
+
+				s = monthStart.Format("Jan 2006") + " - " + monthEnd.Format("Jan 2006")
+			}
 		}
 	}
 	// 4. Convert BLOCK CAPS to Title Caps

--- a/render/helpers_test.go
+++ b/render/helpers_test.go
@@ -211,6 +211,12 @@ func TestDatePeriodFormat(t *testing.T) {
 		So(got, ShouldEqual, want)
 
 	})
+	Convey("Given a time-series monthly string spanning two different years", t, func() {
+		want := "Dec - Jan 2011"
+		got := DatePeriodFormat("2010 DEC-JAN")
+		So(got, ShouldEqual, want)
+
+	})
 	Convey("Given a time-series yearly string", t, func() {
 		want := "2019"
 		got := DatePeriodFormat("2019")
@@ -241,7 +247,6 @@ func TestDatePeriodFormat(t *testing.T) {
 		got := DatePeriodFormat("Q4 2019")
 		So(got, ShouldEqual, want)
 	})
-
 }
 
 func TestDateFormatYYYYMMDDNoSlash(t *testing.T) {

--- a/render/helpers_test.go
+++ b/render/helpers_test.go
@@ -212,7 +212,7 @@ func TestDatePeriodFormat(t *testing.T) {
 
 	})
 	Convey("Given a time-series monthly string spanning two different years", t, func() {
-		want := "Dec - Jan 2011"
+		want := "Dec 2010 - Jan 2011"
 		got := DatePeriodFormat("2010 DEC-JAN")
 		So(got, ShouldEqual, want)
 


### PR DESCRIPTION
### What

Added further processing of string if over a certain length i.e. if the string containing the date range holds two months and a year. 

Fix needed because original code would move year provided by the start month and put it after the end month resulting in 2020 DEC - FEB becoming DEC - FEB 2020 when it should be DEC - FEB 2021.

Further discussions has resulted in the desired output being DEC 2020 - FEB 2021 and the code added reflects that desire.

### How to review

LGTM / Feel free to pull and check locally.

### Who can review

Someone familiar with GO