### PR TITLE
Replace gorilla/pat with gorilla/mux (+go 1.17)

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.13.8
+    tag: 1.17.9
 
 inputs:
   - name: dp-frontend-renderer

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.13.8
+    tag: 1.17.9
 
 inputs:
   - name: dp-frontend-renderer

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dp-frontend-renderer
 
-go 1.13
+go 1.17
 
 require (
 	github.com/BurntSushi/toml v0.3.1
@@ -9,20 +9,31 @@ require (
 	github.com/ONSdigital/go-ns v0.0.0-20210831102424-ebdecc20fe9e
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2
-	github.com/gorilla/context v1.1.1 // indirect
-	github.com/gorilla/pat v1.0.1
+	github.com/gorilla/mux v1.8.0
 	github.com/gosimple/slug v1.9.0
 	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/justinas/alice v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/nicksnyder/go-i18n/v2 v2.1.2
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/unrolled/render v1.0.3
 	golang.org/x/text v0.3.5
 	gopkg.in/russross/blackfriday.v2 v2.1.0
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/fatih/color v1.12.0 // indirect
+	github.com/gopherjs/gopherjs v0.0.0-20210202160940-bed99a852dfe // indirect
+	github.com/hokaccha/go-prettyjson v0.0.0-20210113012101-fb4e108d2519 // indirect
+	github.com/jtolds/gls v4.20.0+incompatible // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/smartystreets/assertions v1.2.0 // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
 )
 
 // This dependency fails if used directly. We need to do this replace. More info: https://github.com/russross/blackfriday/issues/500

--- a/go.sum
+++ b/go.sum
@@ -48,13 +48,9 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20210202160940-bed99a852dfe h1:rcf1P0fm+1l0EjG16p06mYLj9gW9X36KgdHJ/88hS4g=
 github.com/gopherjs/gopherjs v0.0.0-20210202160940-bed99a852dfe/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
-github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gorilla/pat v1.0.1 h1:OeSoj6sffw4/majibAY2BAUsXjNP7fEE+w30KickaL4=
-github.com/gorilla/pat v1.0.1/go.mod h1:YeAe0gNeiNT5hoiZRI4yiOky6jVdNvfO2N6Kav/HmxY=
 github.com/gorilla/schema v1.1.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/gosimple/slug v1.9.0 h1:r5vDcYrFz9BmfIAMC829un9hq7hKM4cHUrsv36LbEqs=
 github.com/gosimple/slug v1.9.0/go.mod h1:AMZ+sOVe65uByN3kgEyf9WEBKBCSS+dJjMX9x4vDJbg=
@@ -129,7 +125,6 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/avro.v0 v0.0.0-20171217001914-a730b5802183/go.mod h1:FvqrFXt+jCsyQibeRv4xxEJBL5iG2DDW5aeJwzDiq4A=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/handlers/homepage/handler_test.go
+++ b/handlers/homepage/handler_test.go
@@ -12,7 +12,7 @@ import (
 	homepage "github.com/ONSdigital/dp-frontend-models/model/homepage"
 	"github.com/ONSdigital/dp-frontend-renderer/config"
 	"github.com/ONSdigital/go-ns/render"
-	"github.com/gorilla/pat"
+	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
 	unrolled "github.com/unrolled/render"
 )
@@ -48,7 +48,7 @@ func doTestRequest(target string, req *http.Request, handlerFunc http.HandlerFun
 	if w == nil {
 		w = httptest.NewRecorder()
 	}
-	router := pat.New()
+	router := mux.NewRouter()
 	router.HandleFunc(target, handlerFunc)
 	router.ServeHTTP(w, req)
 	return w

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -18,24 +18,26 @@ import (
 	"github.com/ONSdigital/dp-frontend-renderer/handlers/homepage"
 	"github.com/ONSdigital/dp-frontend-renderer/handlers/productPage"
 	"github.com/ONSdigital/dp-healthcheck/healthcheck"
-	"github.com/gorilla/pat"
+	"github.com/gorilla/mux"
+	"net/http"
 )
 
-func Setup(router *pat.Router, cfg *config.Config, hc *healthcheck.HealthCheck) {
-	router.Get("/health", hc.Handler)
-	router.Post("/homepage", homepage.Handler(*cfg))
-	router.Post("/feedback", feedback.Handler(*cfg))
-	router.Post("/productPage", productPage.Handler(*cfg))
-	router.Post("/error", errorPage.Handler(*cfg))
-	router.Post("/dataset-filter/preview-page", previewPage.Handler(*cfg))
-	router.Post("/dataset-filter/geography", geography.Handler(*cfg))
-	router.Post("/dataset-filter/hierarchy", hierarchy.Handler(*cfg))
-	router.Post("/dataset-filter/filter-overview", filterOverview.Handler(*cfg))
-	router.Post("/dataset-filter/list-selector", listSelector.Handler(*cfg))
-	router.Post("/dataset-filter/time", timeSelector.Handler(*cfg))
-	router.Post("/dataset-filter/age", ageSelector.Handler(*cfg))
-	router.Post("/geography-homepage", geographyHomepage.Handler(*cfg))
-	router.Post("/geography-list", geographyList.Handler(*cfg))
-	router.Post("/geography-area", geographyArea.Handler(*cfg))
-	router.Post("/cookies-preferences", cookies.Handler(*cfg))
+func Setup(router *mux.Router, cfg *config.Config, hc *healthcheck.HealthCheck) {
+	router.Path("/health").HandlerFunc(hc.Handler).Methods(http.MethodGet)
+	router.Path("/homepage").Handler(homepage.Handler(*cfg)).Methods(http.MethodPost)
+	router.Path("/homepage").Handler(homepage.Handler(*cfg)).Methods(http.MethodPost)
+	router.Path("/feedback").Handler(feedback.Handler(*cfg)).Methods(http.MethodPost)
+	router.Path("/productPage").Handler(productPage.Handler(*cfg)).Methods(http.MethodPost)
+	router.Path("/error").Handler(errorPage.Handler(*cfg)).Methods(http.MethodPost)
+	router.Path("/dataset-filter/preview-page").Handler(previewPage.Handler(*cfg)).Methods(http.MethodPost)
+	router.Path("/dataset-filter/geography").Handler(geography.Handler(*cfg)).Methods(http.MethodPost)
+	router.Path("/dataset-filter/hierarchy").Handler(hierarchy.Handler(*cfg)).Methods(http.MethodPost)
+	router.Path("/dataset-filter/filter-overview").Handler(filterOverview.Handler(*cfg)).Methods(http.MethodPost)
+	router.Path("/dataset-filter/list-selector").Handler(listSelector.Handler(*cfg)).Methods(http.MethodPost)
+	router.Path("/dataset-filter/time").Handler(timeSelector.Handler(*cfg)).Methods(http.MethodPost)
+	router.Path("/dataset-filter/age").Handler(ageSelector.Handler(*cfg)).Methods(http.MethodPost)
+	router.Path("/geography-homepage").Handler(geographyHomepage.Handler(*cfg)).Methods(http.MethodPost)
+	router.Path("/geography-list").Handler(geographyList.Handler(*cfg)).Methods(http.MethodPost)
+	router.Path("/geography-area").Handler(geographyArea.Handler(*cfg)).Methods(http.MethodPost)
+	router.Path("/cookies-preferences").Handler(cookies.Handler(*cfg)).Methods(http.MethodPost)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ONSdigital/go-ns/handlers/requestID"
 	"github.com/ONSdigital/go-ns/render"
 	"github.com/ONSdigital/log.go/v2/log"
-	"github.com/gorilla/pat"
+	"github.com/gorilla/mux"
 	"github.com/justinas/alice"
 	unrolled "github.com/unrolled/render"
 )
@@ -57,7 +57,7 @@ func Run(ctx context.Context, cfg *config.Config, taxonomyRedirects map[string]s
 	})
 
 	// Create router with middleware and routes
-	router := pat.New()
+	router := mux.NewRouter()
 	alice := alice.New(
 		timeoutHandler(10*time.Second),
 		log.Middleware,


### PR DESCRIPTION
### What

A security vulnerability in the `gorilla/pat` router allows a maliciously crafted url to act as an open redirect. Although the dp-frontend-renderer is deprecated and not directly available externally, an attacker could theoretically craft a malicious redirect eg. in an email to an internal staff member. `gorilla/mux` does not suffer from the same vulnerability as it correctly escapes the url supplied to the Location header when performing a 301 redirect.

### How to review

Ensure the service no longer uses `gorilla/pat` for routing and that an appropriate test exists and passes.

### Who can review

Anyone but me