### PR TITLE
Use 'printf' to add build flags when generating assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,14 @@ debug: generate-debug
 generate-debug:
 	# build the dev version
 	cd assets; go run github.com/jteeuwen/go-bindata/go-bindata -debug -o data.go -pkg assets templates/... locales/...
-	{ echo "// +build debug\n"; cat assets/data.go; } > assets/debug.go.new
+	{ printf "// +build debug\n"; cat assets/data.go; } > assets/debug.go.new
 	mv assets/debug.go.new assets/data.go
 
 .PHONY: generate-prod
 generate-prod:
 	# build the production version
 	cd assets; go run github.com/jteeuwen/go-bindata/go-bindata -o data.go -pkg assets templates/... locales/...
-	{ echo "// +build production\n"; cat assets/data.go; } > assets/data.go.new
+	{ printf "// +build production\n"; cat assets/data.go; } > assets/data.go.new
 	mv assets/data.go.new assets/data.go
 
 .PHONY: test


### PR DESCRIPTION
Running zsh on a linux machine the `\n` (newline) character was being
added to the `data.go` file when using the `echo` command.
Additionally the `echo -e` of `echo -E` options for backslash
interpretation are not available on Darwin/bsd.


### What

Describe what you have changed and why.

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
