### PR TITLE
remove redirect

### DIFF
--- a/assets/templates/partials/feedback.tmpl
+++ b/assets/templates/partials/feedback.tmpl
@@ -2,7 +2,7 @@
     <div class="improve-this-page" data-module="improve-this-page">
         <div class="improve-this-page__prompt clearfix" id="feedback-form-header" role="status" aria-live="polite" tabindex="-1">
             <h3 class="improve-this-page__is-useful-question margin-right--1">Is this page useful?</h3>
-            <a id="feedback-form-yes" class="improve-this-page__page-is-useful-button" href="/feedback/thanks" aria-label="Yes I found this page useful">
+            <a id="feedback-form-yes" class="improve-this-page__page-is-useful-button" href="" aria-label="Yes I found this page useful">
                 Yes
             </a>
             <span>|</span>


### PR DESCRIPTION
### What

Feedback partial is redirecting to nonexistent `feedback-thanks` page causing a `503` on the website along with the message "Something went wrong, try using our feedback form."

### How to review

See that link to `feedback-thanks` has been removed. 

### Who can review

Frontend dev
